### PR TITLE
fix(performerImageSearch): UX improvements for settings and image loading

### DIFF
--- a/plugins/performerImageSearch/performer-image-search.css
+++ b/plugins/performerImageSearch/performer-image-search.css
@@ -150,6 +150,16 @@
   border-color: #0a58ca;
 }
 
+.pis-btn-loading {
+  opacity: 0.7;
+  cursor: wait;
+}
+
+.pis-btn:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
 /* Modal Body - Results Grid */
 .pis-modal-body {
   flex: 1;
@@ -181,6 +191,8 @@
   cursor: pointer;
   background: #2a2a2a;
   transition: transform 0.2s, box-shadow 0.2s;
+  /* Prevent layout shift by reserving space */
+  contain: layout style;
 }
 
 .pis-result-item:hover {
@@ -193,6 +205,32 @@
   width: 100%;
   height: 100%;
   object-fit: cover;
+  /* Smooth fade-in when image loads */
+  opacity: 0;
+  transition: opacity 0.2s ease-in;
+}
+
+.pis-result-item img.pis-loaded {
+  opacity: 1;
+}
+
+/* Failed images show placeholder instead of hiding */
+.pis-result-item.pis-error {
+  opacity: 0.4;
+}
+
+.pis-result-item.pis-error img {
+  display: none;
+}
+
+.pis-result-item.pis-error::before {
+  content: "×";
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  font-size: 32px;
+  color: #666;
 }
 
 .pis-result-info {

--- a/plugins/performerImageSearch/performer-image-search.js
+++ b/plugins/performerImageSearch/performer-image-search.js
@@ -362,7 +362,7 @@
           <img id="pis-preview-image" src="" alt="Preview" />
           <div id="pis-preview-dims" class="pis-preview-dims"></div>
           <div class="pis-preview-actions">
-            <button class="pis-btn pis-btn-primary" onclick="window.pisConfirmImage()">Set as Performer Image</button>
+            <button id="pis-confirm-btn" class="pis-btn pis-btn-primary" onclick="window.pisConfirmImage()">Set as Performer Image</button>
             <button class="pis-btn" onclick="window.pisClosePreview()">Cancel</button>
           </div>
         </div>
@@ -542,8 +542,8 @@
             src="${escapeHtml(result.thumbnail)}"
             alt="${escapeHtml(result.title)}"
             loading="lazy"
-            onload="window.pisImageLoaded(this, ${originalIndex})"
-            onerror="this.parentElement.style.display='none'"
+            onload="this.classList.add('pis-loaded'); window.pisImageLoaded(this, ${originalIndex})"
+            onerror="this.parentElement.classList.add('pis-error')"
           />
           <div class="pis-result-info">
             ${escapeHtml(result.source)}
@@ -608,11 +608,25 @@
   window.pisConfirmImage = async function () {
     if (!previewImage || !currentPerformerId) return;
 
+    const confirmBtn = document.getElementById("pis-confirm-btn");
+    const originalText = confirmBtn?.textContent;
+
+    // Show loading state on button
+    if (confirmBtn) {
+      confirmBtn.disabled = true;
+      confirmBtn.textContent = "Saving...";
+      confirmBtn.classList.add("pis-btn-loading");
+    }
+
     showStatus("Setting performer image...", "loading");
 
     try {
       await setPerformerImage(currentPerformerId, previewImage);
       showStatus("Image set successfully!", "success");
+
+      if (confirmBtn) {
+        confirmBtn.textContent = "Saved!";
+      }
 
       // Close modal after brief delay
       setTimeout(() => {
@@ -622,6 +636,12 @@
       }, 1000);
     } catch (e) {
       showStatus(`Failed to set image: ${e.message}`, "error");
+      // Restore button state on error
+      if (confirmBtn) {
+        confirmBtn.disabled = false;
+        confirmBtn.textContent = originalText;
+        confirmBtn.classList.remove("pis-btn-loading");
+      }
     }
   };
 

--- a/plugins/performerImageSearch/performerImageSearch.yml
+++ b/plugins/performerImageSearch/performerImageSearch.yml
@@ -1,6 +1,6 @@
 name: Performer Image Search
 description: Search multiple sources for performer images. Supports mainstream, JAV, male, and trans performers with configurable sources.
-version: 1.2.0
+version: 1.2.1
 url: https://github.com/carrotwaxr/stash-plugins
 
 # UI plugin - injects button and modal on performer pages
@@ -16,39 +16,48 @@ settings:
     displayName: Default Search Suffix
     description: Text appended to performer name when searching (e.g., "pornstar solo")
     type: STRING
+    default: "pornstar"
   defaultLayout:
     displayName: Default Layout
     description: Default aspect ratio filter (All, Portrait, Landscape, Square)
     type: STRING
+    default: "All"
   # Source toggles - all enabled by default
   enableBabepedia:
     displayName: Enable Babepedia
     description: Female performers only. Curated photos.
     type: BOOLEAN
+    default: true
   enablePornPics:
     displayName: Enable PornPics
     description: Mainstream performers. Has male performers.
     type: BOOLEAN
+    default: true
   enableFreeOnes:
     displayName: Enable FreeOnes
     description: Large database with male and trans performers.
     type: BOOLEAN
+    default: true
   enableEliteBabes:
     displayName: Enable EliteBabes
     description: Female performers only. High-quality photosets.
     type: BOOLEAN
+    default: true
   enableBoobpedia:
     displayName: Enable Boobpedia
     description: Female performers only. Wiki-style database.
     type: BOOLEAN
+    default: true
   enableJavDatabase:
     displayName: Enable JavDatabase
     description: Japanese adult video performers.
     type: BOOLEAN
+    default: true
   enableBing:
     displayName: Enable Bing Images
     description: Fallback search. Works for all performer types.
     type: BOOLEAN
+    default: true
 
 # Python backend for image search (called via runPluginOperation from JS)
 exec:


### PR DESCRIPTION
## Summary

Fixes three UX issues with the Performer Image Search plugin:

### 1. Settings defaults not showing correctly
- Added `default: true` to all BOOLEAN settings in YAML
- Added `default: "pornstar"` and `default: "All"` to STRING settings
- Now Stash UI correctly shows toggles as "on" by default

### 2. No loading feedback when saving image
- "Set as Performer Image" button now shows "Saving..." state when clicked
- Button is disabled during save to prevent double-clicks
- Changes to "Saved!" on success before modal closes
- Restores original state on error

### 3. Layout shift when images load
- Added CSS `contain: layout style` to prevent reflow
- Images now fade in smoothly with opacity transition
- Failed images show a styled "×" placeholder instead of disappearing
- This prevents grid items from jumping around as images load

## Testing
- Install plugin update
- Verify Settings > Plugins shows all toggles as ON by default
- Search for images, verify smooth fade-in without layout jumps
- Click "Set as Performer Image" and verify button shows loading state

🤖 Generated with [Claude Code](https://claude.com/claude-code)