### PR TITLE
feat(missingScenes): add Missing Scenes plugin v1.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,17 +27,30 @@ Generate NFO metadata files for Jellyfin/Emby, organize/rename video files, and 
 
 [Documentation](plugins/mcMetadata/README.md)
 
-### Performer Image Search (v1.1.0)
+### Performer Image Search (v1.2.2)
 
 Search multiple image sources directly from performer pages and set images with one click.
 
 **Features:**
-- Search Babepedia, PornPics, FreeOnes, EliteBabes, Boobpedia, and Bing
+- Search Babepedia, PornPics, FreeOnes, EliteBabes, Boobpedia, JavDatabase, and Bing
 - Preview images before setting
 - Filter by aspect ratio (portrait, landscape, square)
 - Customizable search suffix
 
 [Documentation](plugins/performerImageSearch/README.md)
+
+### Missing Scenes (v1.0.0)
+
+Discover scenes from StashDB that you don't have in your local library.
+
+**Features:**
+- Find missing scenes for any performer or studio linked to StashDB
+- Visual grid with thumbnails, titles, dates, and performer info
+- Direct links to view scenes on StashDB
+- Multi-endpoint support (StashDB, FansDB, etc.)
+- Optional Whisparr integration for automated downloading
+
+[Documentation](plugins/missingScenes/README.md)
 
 ## Support
 

--- a/plugins/missingScenes/README.md
+++ b/plugins/missingScenes/README.md
@@ -1,0 +1,80 @@
+# Missing Scenes
+
+Discover scenes from StashDB (or other stash-box instances) that you don't have in your local Stash library.
+
+## Features
+
+- **Performer & Studio Support**: Find missing scenes for any performer or studio linked to a stash-box
+- **Visual Grid Display**: Browse missing scenes with thumbnails, titles, dates, and performer info
+- **Direct StashDB Links**: Click any scene to view it on StashDB
+- **Multi-Endpoint Support**: Works with StashDB, FansDB, or any configured stash-box endpoint
+- **Whisparr Integration** (Optional): Add missing scenes directly to Whisparr for automated downloading
+
+## Requirements
+
+- Stash v0.25.0 or later (requires `runPluginOperation` GraphQL mutation)
+- At least one stash-box endpoint configured (Settings → Metadata Providers → Stash-box Endpoints)
+- Performers/Studios must be linked to stash-box (use the Tagger to link them)
+
+## Usage
+
+1. Navigate to any **Performer** or **Studio** detail page
+2. Click the **Missing Scenes** button in the header
+3. The plugin will:
+   - Query the configured stash-box for all scenes featuring that performer/studio
+   - Compare against your local Stash library
+   - Display scenes you don't have
+
+## Settings
+
+Configure in **Settings → Plugins → Missing Scenes**:
+
+| Setting | Description |
+|---------|-------------|
+| **Stash-Box Endpoint** | Which stash-box to query. Leave empty to use the first configured endpoint (usually StashDB). Enter the full GraphQL URL (e.g., `https://stashdb.org/graphql`). |
+| **Whisparr URL** | Optional. URL to your Whisparr instance (e.g., `http://localhost:6969`). |
+| **Whisparr API Key** | Optional. API key from Whisparr Settings → General → Security. |
+| **Quality Profile ID** | Whisparr quality profile ID (default: 1). |
+| **Root Folder** | Whisparr root folder path for downloaded scenes. |
+| **Search on Add** | Automatically search for scenes when adding to Whisparr. |
+
+## Whisparr Integration
+
+When Whisparr is configured:
+- Each missing scene shows an "Add to Whisparr" button
+- "Add All to Whisparr" button appears to bulk-add all missing scenes
+- Scenes already in Whisparr are marked and disabled
+
+**Note**: Whisparr v3 API is supported. The plugin uses `stash:{scene_id}` as the foreign ID format.
+
+## How It Works
+
+1. **Get Entity**: Fetches the performer/studio from your local Stash
+2. **Find Stash ID**: Looks up the stash-box ID for that entity
+3. **Query Stash-Box**: Fetches all scenes from the stash-box (paginated, up to 1000 scenes)
+4. **Get Local Scenes**: Fetches all your local scene stash IDs
+5. **Compare**: Filters out scenes you already have
+6. **Display**: Shows missing scenes sorted by release date (newest first)
+
+## Troubleshooting
+
+### "Performer/Studio is not linked to StashDB"
+The entity needs a stash_id for the configured stash-box endpoint. Use the Tagger (Scenes → Tagger) to match and link the performer/studio.
+
+### "No stash-box endpoints configured"
+Go to Settings → Metadata Providers → Stash-box Endpoints and add at least one endpoint (e.g., StashDB).
+
+### Results seem incomplete
+The plugin fetches up to 1000 scenes (10 pages of 100). For performers/studios with more scenes, the oldest scenes may be excluded.
+
+## Technical Details
+
+- **UI Plugin**: JavaScript + CSS injected on performer/studio pages
+- **Backend**: Python script called via `runPluginOperation` GraphQL mutation
+- **No External Dependencies**: Uses only Python standard library
+- **Pagination**: Fetches 100 scenes per page from stash-box
+- **Caching**: Scene stash IDs are fetched fresh each time (no caching)
+
+## License
+
+MIT License

--- a/plugins/missingScenes/log.py
+++ b/plugins/missingScenes/log.py
@@ -1,0 +1,44 @@
+"""
+Stash plugin logging module.
+Log messages are transmitted via stderr with special character encoding.
+"""
+import sys
+
+
+def __prefix(level_char):
+    start_level_char = b'\x01'
+    end_level_char = b'\x02'
+    ret = start_level_char + level_char + end_level_char
+    return ret.decode()
+
+
+def __log(level_char, s):
+    if level_char == "":
+        return
+    print(__prefix(level_char) + s + "\n", file=sys.stderr, flush=True)
+
+
+def LogTrace(s):
+    __log(b't', s)
+
+
+def LogDebug(s):
+    __log(b'd', s)
+
+
+def LogInfo(s):
+    __log(b'i', s)
+
+
+def LogWarning(s):
+    __log(b'w', s)
+
+
+def LogError(s):
+    __log(b'e', s)
+
+
+def LogProgress(p):
+    """Log progress (0.0 to 1.0)"""
+    progress = min(max(0, p), 1)
+    __log(b'p', str(progress))

--- a/plugins/missingScenes/missing-scenes.css
+++ b/plugins/missingScenes/missing-scenes.css
@@ -1,0 +1,423 @@
+/* Missing Scenes Plugin Styles */
+
+/* Search Button */
+.ms-search-button {
+  display: inline-flex;
+  align-items: center;
+  margin-left: 8px;
+}
+
+.ms-button-container {
+  display: inline-flex;
+  align-items: center;
+}
+
+/* Modal Backdrop */
+.ms-modal-backdrop {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0, 0, 0, 0.85);
+  z-index: 10000;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 20px;
+}
+
+/* Modal Container */
+.ms-modal {
+  background: #1a1a1a;
+  border-radius: 8px;
+  width: 100%;
+  max-width: 1200px;
+  max-height: 90vh;
+  display: flex;
+  flex-direction: column;
+  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.5);
+  border: 1px solid #333;
+}
+
+/* Modal Header */
+.ms-modal-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 16px 20px;
+  border-bottom: 1px solid #333;
+}
+
+.ms-modal-header h3 {
+  margin: 0;
+  font-size: 18px;
+  color: #fff;
+}
+
+.ms-close-btn {
+  background: none;
+  border: none;
+  color: #888;
+  font-size: 28px;
+  cursor: pointer;
+  padding: 0;
+  line-height: 1;
+  transition: color 0.2s;
+}
+
+.ms-close-btn:hover {
+  color: #fff;
+}
+
+/* Stats Bar */
+.ms-stats-bar {
+  display: flex;
+  gap: 24px;
+  padding: 12px 20px;
+  background: #222;
+  border-bottom: 1px solid #333;
+  flex-wrap: wrap;
+}
+
+.ms-stat {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+}
+
+.ms-stat-label {
+  color: #888;
+  font-size: 13px;
+}
+
+.ms-stat-value {
+  color: #fff;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.ms-stat-highlight .ms-stat-value {
+  color: #ffc107;
+  font-size: 16px;
+}
+
+/* Modal Body - Results Grid */
+.ms-modal-body {
+  flex: 1;
+  overflow-y: auto;
+  padding: 20px;
+  min-height: 300px;
+}
+
+.ms-results-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+  gap: 16px;
+}
+
+/* Placeholder States */
+.ms-placeholder {
+  grid-column: 1 / -1;
+  text-align: center;
+  color: #888;
+  padding: 60px 20px;
+  font-size: 16px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 16px;
+}
+
+.ms-placeholder.ms-success {
+  color: #198754;
+}
+
+.ms-placeholder.ms-error {
+  color: #dc3545;
+}
+
+.ms-success-icon {
+  font-size: 48px;
+  color: #198754;
+}
+
+.ms-error-icon {
+  width: 48px;
+  height: 48px;
+  border-radius: 50%;
+  background: #dc3545;
+  color: #fff;
+  font-size: 32px;
+  font-weight: bold;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+/* Spinner */
+.ms-spinner {
+  width: 40px;
+  height: 40px;
+  border: 3px solid #333;
+  border-top-color: #0d6efd;
+  border-radius: 50%;
+  animation: ms-spin 1s linear infinite;
+}
+
+@keyframes ms-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+/* Scene Card */
+.ms-scene-card {
+  background: #2a2a2a;
+  border-radius: 8px;
+  overflow: hidden;
+  cursor: pointer;
+  transition: transform 0.2s, box-shadow 0.2s;
+  display: flex;
+  flex-direction: column;
+}
+
+.ms-scene-card:hover {
+  transform: translateY(-4px);
+  box-shadow: 0 8px 25px rgba(0, 0, 0, 0.4);
+}
+
+/* Scene Thumbnail */
+.ms-scene-thumb {
+  position: relative;
+  width: 100%;
+  padding-top: 56.25%; /* 16:9 aspect ratio */
+  background: #1a1a1a;
+  overflow: hidden;
+}
+
+.ms-scene-thumb img {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  opacity: 0;
+  transition: opacity 0.3s ease-in;
+}
+
+.ms-scene-thumb img.ms-loaded {
+  opacity: 1;
+}
+
+.ms-scene-thumb.ms-no-image {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.ms-no-image-icon {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  font-size: 32px;
+  color: #444;
+}
+
+/* Scene Info */
+.ms-scene-info {
+  padding: 12px;
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.ms-scene-title {
+  font-size: 14px;
+  font-weight: 600;
+  color: #fff;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.ms-scene-meta {
+  font-size: 12px;
+  color: #888;
+}
+
+.ms-scene-performers {
+  font-size: 12px;
+  color: #aaa;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+/* Scene Actions */
+.ms-scene-actions {
+  display: flex;
+  gap: 8px;
+  padding: 8px 12px 12px;
+  border-top: 1px solid #333;
+}
+
+/* Buttons */
+.ms-btn {
+  padding: 8px 16px;
+  border: 1px solid #444;
+  border-radius: 4px;
+  background: #2a2a2a;
+  color: #fff;
+  font-size: 13px;
+  cursor: pointer;
+  transition: all 0.2s;
+  text-decoration: none;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.ms-btn:hover {
+  background: #3a3a3a;
+  border-color: #555;
+  color: #fff;
+  text-decoration: none;
+}
+
+.ms-btn-small {
+  padding: 6px 12px;
+  font-size: 12px;
+  flex: 1;
+}
+
+.ms-btn-primary {
+  background: #0d6efd;
+  border-color: #0d6efd;
+}
+
+.ms-btn-primary:hover {
+  background: #0b5ed7;
+  border-color: #0a58ca;
+}
+
+.ms-btn-whisparr {
+  background: #6f42c1;
+  border-color: #6f42c1;
+}
+
+.ms-btn-whisparr:hover {
+  background: #5a32a3;
+  border-color: #5a32a3;
+}
+
+.ms-btn-loading {
+  opacity: 0.7;
+  cursor: wait;
+}
+
+.ms-btn-disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+  background: #333 !important;
+  border-color: #333 !important;
+}
+
+.ms-btn-success {
+  background: #198754 !important;
+  border-color: #198754 !important;
+}
+
+.ms-btn-error {
+  background: #dc3545 !important;
+  border-color: #dc3545 !important;
+}
+
+.ms-btn:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+/* Modal Footer */
+.ms-modal-footer {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 12px 20px;
+  border-top: 1px solid #333;
+}
+
+.ms-footer-actions {
+  display: flex;
+  gap: 12px;
+}
+
+/* Status Messages */
+.ms-status {
+  font-size: 13px;
+  color: #888;
+}
+
+.ms-status-loading {
+  color: #0d6efd;
+}
+
+.ms-status-success {
+  color: #198754;
+}
+
+.ms-status-error {
+  color: #dc3545;
+}
+
+/* Scrollbar Styling */
+.ms-modal-body::-webkit-scrollbar {
+  width: 8px;
+}
+
+.ms-modal-body::-webkit-scrollbar-track {
+  background: #1a1a1a;
+}
+
+.ms-modal-body::-webkit-scrollbar-thumb {
+  background: #444;
+  border-radius: 4px;
+}
+
+.ms-modal-body::-webkit-scrollbar-thumb:hover {
+  background: #555;
+}
+
+/* Responsive Adjustments */
+@media (max-width: 768px) {
+  .ms-modal {
+    max-width: 100%;
+    max-height: 100vh;
+    border-radius: 0;
+  }
+
+  .ms-results-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .ms-stats-bar {
+    flex-direction: column;
+    gap: 8px;
+  }
+
+  .ms-modal-footer {
+    flex-direction: column;
+    gap: 12px;
+  }
+
+  .ms-scene-actions {
+    flex-direction: column;
+  }
+
+  .ms-btn-small {
+    width: 100%;
+  }
+}

--- a/plugins/missingScenes/missing-scenes.js
+++ b/plugins/missingScenes/missing-scenes.js
@@ -1,0 +1,732 @@
+(function () {
+  "use strict";
+
+  const PLUGIN_ID = "missingScenes";
+
+  // State
+  let modalRoot = null;
+  let currentEntityId = null;
+  let currentEntityType = null; // "performer" or "studio"
+  let currentEntityName = null;
+  let missingScenes = [];
+  let isLoading = false;
+  let whisparrConfigured = false;
+  let stashdbUrl = "";
+
+  /**
+   * Get the GraphQL endpoint URL
+   */
+  function getGraphQLUrl() {
+    const baseEl = document.querySelector("base");
+    const baseURL = baseEl ? baseEl.getAttribute("href") : "/";
+    return `${baseURL}graphql`;
+  }
+
+  /**
+   * Make a GraphQL request using fetch
+   */
+  async function graphqlRequest(query, variables = {}) {
+    const response = await fetch(getGraphQLUrl(), {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ query, variables }),
+    });
+
+    if (!response.ok) {
+      throw new Error(`GraphQL request failed: ${response.status}`);
+    }
+
+    const result = await response.json();
+
+    if (result.errors && result.errors.length > 0) {
+      throw new Error(result.errors[0].message);
+    }
+
+    return result.data;
+  }
+
+  /**
+   * Run a plugin operation via GraphQL
+   */
+  async function runPluginOperation(args) {
+    const query = `
+      mutation RunPluginOperation($plugin_id: ID!, $args: Map) {
+        runPluginOperation(plugin_id: $plugin_id, args: $args)
+      }
+    `;
+
+    const data = await graphqlRequest(query, {
+      plugin_id: PLUGIN_ID,
+      args: args,
+    });
+
+    const rawOutput = data?.runPluginOperation;
+
+    if (!rawOutput) {
+      throw new Error("No response from plugin");
+    }
+
+    // Parse JSON string response from plugin
+    // Stash may return either a string (needs parsing) or already-parsed object
+    // It also auto-unwraps the "output" field from PluginOutput structure
+    let output;
+    try {
+      output = typeof rawOutput === "string" ? JSON.parse(rawOutput) : rawOutput;
+    } catch (e) {
+      console.error("[MissingScenes] Failed to parse plugin response:", rawOutput);
+      throw new Error("Invalid response from plugin");
+    }
+
+    // Check for error
+    if (output.error) {
+      throw new Error(output.error);
+    }
+
+    return output;
+  }
+
+  /**
+   * Find missing scenes for the current entity
+   */
+  async function findMissingScenes(entityType, entityId) {
+    return runPluginOperation({
+      operation: "find_missing",
+      entity_type: entityType,
+      entity_id: entityId,
+    });
+  }
+
+  /**
+   * Add a scene to Whisparr
+   */
+  async function addToWhisparr(stashId, title) {
+    return runPluginOperation({
+      operation: "add_to_whisparr",
+      stash_id: stashId,
+      title: title,
+    });
+  }
+
+  /**
+   * Format duration from seconds to HH:MM:SS or MM:SS
+   */
+  function formatDuration(seconds) {
+    if (!seconds) return "";
+    const hrs = Math.floor(seconds / 3600);
+    const mins = Math.floor((seconds % 3600) / 60);
+    const secs = seconds % 60;
+
+    if (hrs > 0) {
+      return `${hrs}:${mins.toString().padStart(2, "0")}:${secs.toString().padStart(2, "0")}`;
+    }
+    return `${mins}:${secs.toString().padStart(2, "0")}`;
+  }
+
+  /**
+   * Format date for display
+   */
+  function formatDate(dateStr) {
+    if (!dateStr) return "";
+    try {
+      const date = new Date(dateStr);
+      return date.toLocaleDateString(undefined, {
+        year: "numeric",
+        month: "short",
+        day: "numeric",
+      });
+    } catch {
+      return dateStr;
+    }
+  }
+
+  /**
+   * Create the modal UI
+   */
+  function createModal() {
+    // Remove any existing modal
+    removeModal();
+
+    // Create backdrop
+    const backdrop = document.createElement("div");
+    backdrop.className = "ms-modal-backdrop";
+    backdrop.onclick = (e) => {
+      if (e.target === backdrop) {
+        removeModal();
+      }
+    };
+
+    // Create modal
+    const modal = document.createElement("div");
+    modal.className = "ms-modal";
+
+    // Header
+    const header = document.createElement("div");
+    header.className = "ms-modal-header";
+    header.innerHTML = `
+      <h3>Missing Scenes</h3>
+      <button class="ms-close-btn" title="Close">&times;</button>
+    `;
+    header.querySelector(".ms-close-btn").onclick = removeModal;
+
+    // Stats bar
+    const stats = document.createElement("div");
+    stats.className = "ms-stats-bar";
+    stats.id = "ms-stats";
+
+    // Body (results)
+    const body = document.createElement("div");
+    body.className = "ms-modal-body";
+    body.id = "ms-results";
+    body.innerHTML = '<div class="ms-placeholder">Click "Find Missing Scenes" to search...</div>';
+
+    // Footer
+    const footer = document.createElement("div");
+    footer.className = "ms-modal-footer";
+    footer.innerHTML = `
+      <div class="ms-status" id="ms-status"></div>
+      <div class="ms-footer-actions">
+        <button class="ms-btn" id="ms-add-all-btn" style="display: none;">Add All to Whisparr</button>
+      </div>
+    `;
+
+    // Assemble modal
+    modal.appendChild(header);
+    modal.appendChild(stats);
+    modal.appendChild(body);
+    modal.appendChild(footer);
+    backdrop.appendChild(modal);
+    document.body.appendChild(backdrop);
+
+    modalRoot = backdrop;
+
+    // Keyboard handler for escape
+    const keyHandler = (e) => {
+      if (e.key === "Escape") {
+        removeModal();
+      }
+    };
+    document.addEventListener("keydown", keyHandler);
+    backdrop._keyHandler = keyHandler;
+
+    return modal;
+  }
+
+  /**
+   * Remove the modal
+   */
+  function removeModal() {
+    if (modalRoot) {
+      if (modalRoot._keyHandler) {
+        document.removeEventListener("keydown", modalRoot._keyHandler);
+      }
+      modalRoot.remove();
+      modalRoot = null;
+    }
+  }
+
+  /**
+   * Update the stats bar
+   */
+  function updateStats(data) {
+    const statsEl = document.getElementById("ms-stats");
+    if (!statsEl) return;
+
+    const entityLabel = data.entity_type === "performer" ? "Performer" : "Studio";
+
+    statsEl.innerHTML = `
+      <div class="ms-stat">
+        <span class="ms-stat-label">${entityLabel}:</span>
+        <span class="ms-stat-value">${data.entity_name || "Unknown"}</span>
+      </div>
+      <div class="ms-stat">
+        <span class="ms-stat-label">On ${data.stashdb_name || "StashDB"}:</span>
+        <span class="ms-stat-value">${data.total_on_stashdb || 0}</span>
+      </div>
+      <div class="ms-stat">
+        <span class="ms-stat-label">You Have:</span>
+        <span class="ms-stat-value">${data.total_local || 0}</span>
+      </div>
+      <div class="ms-stat ms-stat-highlight">
+        <span class="ms-stat-label">Missing:</span>
+        <span class="ms-stat-value">${data.missing_count || 0}</span>
+      </div>
+    `;
+  }
+
+  /**
+   * Render the results grid
+   */
+  function renderResults() {
+    const container = document.getElementById("ms-results");
+    if (!container) return;
+
+    if (missingScenes.length === 0) {
+      container.innerHTML = `
+        <div class="ms-placeholder ms-success">
+          <div class="ms-success-icon">&#10003;</div>
+          <div>You have all available scenes!</div>
+        </div>
+      `;
+      return;
+    }
+
+    // Create grid
+    const grid = document.createElement("div");
+    grid.className = "ms-results-grid";
+
+    for (const scene of missingScenes) {
+      const item = createSceneCard(scene);
+      grid.appendChild(item);
+    }
+
+    container.innerHTML = "";
+    container.appendChild(grid);
+
+    // Show "Add All" button if Whisparr is configured
+    const addAllBtn = document.getElementById("ms-add-all-btn");
+    if (addAllBtn && whisparrConfigured) {
+      const notInWhisparr = missingScenes.filter((s) => !s.in_whisparr);
+      if (notInWhisparr.length > 0) {
+        addAllBtn.style.display = "inline-block";
+        addAllBtn.textContent = `Add All to Whisparr (${notInWhisparr.length})`;
+        addAllBtn.onclick = () => handleAddAll(notInWhisparr);
+      }
+    }
+  }
+
+  /**
+   * Create a scene card element
+   */
+  function createSceneCard(scene) {
+    const card = document.createElement("div");
+    card.className = "ms-scene-card";
+    card.dataset.stashId = scene.stash_id;
+
+    // Thumbnail
+    const thumbContainer = document.createElement("div");
+    thumbContainer.className = "ms-scene-thumb";
+
+    if (scene.thumbnail) {
+      const img = document.createElement("img");
+      img.src = scene.thumbnail;
+      img.alt = scene.title;
+      img.loading = "lazy";
+      img.onload = () => img.classList.add("ms-loaded");
+      img.onerror = () => {
+        thumbContainer.classList.add("ms-no-image");
+        thumbContainer.innerHTML = '<span class="ms-no-image-icon">&#128247;</span>';
+      };
+      thumbContainer.appendChild(img);
+    } else {
+      thumbContainer.classList.add("ms-no-image");
+      thumbContainer.innerHTML = '<span class="ms-no-image-icon">&#128247;</span>';
+    }
+
+    // Info overlay
+    const info = document.createElement("div");
+    info.className = "ms-scene-info";
+
+    // Title
+    const title = document.createElement("div");
+    title.className = "ms-scene-title";
+    title.textContent = scene.title;
+    title.title = scene.title;
+
+    // Meta (studio, date, duration)
+    const meta = document.createElement("div");
+    meta.className = "ms-scene-meta";
+
+    const metaParts = [];
+    if (scene.studio?.name) {
+      metaParts.push(scene.studio.name);
+    }
+    if (scene.release_date) {
+      metaParts.push(formatDate(scene.release_date));
+    }
+    if (scene.duration) {
+      metaParts.push(formatDuration(scene.duration));
+    }
+    meta.textContent = metaParts.join(" • ");
+
+    // Performers
+    const performers = document.createElement("div");
+    performers.className = "ms-scene-performers";
+    if (scene.performers && scene.performers.length > 0) {
+      const names = scene.performers.map((p) => p.name).slice(0, 3);
+      performers.textContent = names.join(", ");
+      if (scene.performers.length > 3) {
+        performers.textContent += ` +${scene.performers.length - 3}`;
+      }
+    }
+
+    info.appendChild(title);
+    info.appendChild(meta);
+    info.appendChild(performers);
+
+    // Actions
+    const actions = document.createElement("div");
+    actions.className = "ms-scene-actions";
+
+    // StashDB link
+    const stashdbLink = document.createElement("a");
+    stashdbLink.className = "ms-btn ms-btn-small";
+    stashdbLink.href = `${stashdbUrl}/scenes/${scene.stash_id}`;
+    stashdbLink.target = "_blank";
+    stashdbLink.rel = "noopener noreferrer";
+    stashdbLink.textContent = "View on StashDB";
+    stashdbLink.onclick = (e) => e.stopPropagation();
+    actions.appendChild(stashdbLink);
+
+    // Whisparr button (if configured)
+    if (whisparrConfigured) {
+      const whisparrBtn = document.createElement("button");
+      whisparrBtn.className = "ms-btn ms-btn-small ms-btn-whisparr";
+
+      if (scene.in_whisparr) {
+        whisparrBtn.textContent = "In Whisparr";
+        whisparrBtn.disabled = true;
+        whisparrBtn.classList.add("ms-btn-disabled");
+      } else {
+        whisparrBtn.textContent = "Add to Whisparr";
+        whisparrBtn.onclick = (e) => {
+          e.stopPropagation();
+          handleAddToWhisparr(scene, whisparrBtn);
+        };
+      }
+      actions.appendChild(whisparrBtn);
+    }
+
+    card.appendChild(thumbContainer);
+    card.appendChild(info);
+    card.appendChild(actions);
+
+    // Click card to open on StashDB
+    card.onclick = () => {
+      window.open(`${stashdbUrl}/scenes/${scene.stash_id}`, "_blank");
+    };
+
+    return card;
+  }
+
+  /**
+   * Handle adding a single scene to Whisparr
+   */
+  async function handleAddToWhisparr(scene, button) {
+    const originalText = button.textContent;
+    button.textContent = "Adding...";
+    button.disabled = true;
+    button.classList.add("ms-btn-loading");
+
+    try {
+      await addToWhisparr(scene.stash_id, scene.title);
+
+      // Update button state
+      button.textContent = "Added!";
+      button.classList.remove("ms-btn-loading");
+      button.classList.add("ms-btn-success");
+
+      // Mark scene as in Whisparr
+      scene.in_whisparr = true;
+
+      // Update status
+      setStatus(`Added "${scene.title}" to Whisparr`, "success");
+
+      // After a delay, update button to show final state
+      setTimeout(() => {
+        button.textContent = "In Whisparr";
+        button.classList.remove("ms-btn-success");
+        button.classList.add("ms-btn-disabled");
+      }, 2000);
+    } catch (error) {
+      console.error("[MissingScenes] Failed to add to Whisparr:", error);
+      button.textContent = "Failed";
+      button.classList.remove("ms-btn-loading");
+      button.classList.add("ms-btn-error");
+      button.disabled = false;
+
+      setStatus(`Failed to add: ${error.message}`, "error");
+
+      setTimeout(() => {
+        button.textContent = originalText;
+        button.classList.remove("ms-btn-error");
+      }, 3000);
+    }
+  }
+
+  /**
+   * Handle adding all scenes to Whisparr
+   */
+  async function handleAddAll(scenes) {
+    const addAllBtn = document.getElementById("ms-add-all-btn");
+    if (!addAllBtn) return;
+
+    addAllBtn.disabled = true;
+    addAllBtn.classList.add("ms-btn-loading");
+
+    let added = 0;
+    let failed = 0;
+
+    for (const scene of scenes) {
+      if (scene.in_whisparr) continue;
+
+      setStatus(`Adding ${added + failed + 1}/${scenes.length}: ${scene.title}...`, "loading");
+
+      try {
+        await addToWhisparr(scene.stash_id, scene.title);
+        scene.in_whisparr = true;
+        added++;
+
+        // Update the card's button
+        const card = document.querySelector(`[data-stash-id="${scene.stash_id}"]`);
+        if (card) {
+          const btn = card.querySelector(".ms-btn-whisparr");
+          if (btn) {
+            btn.textContent = "In Whisparr";
+            btn.disabled = true;
+            btn.classList.add("ms-btn-disabled");
+          }
+        }
+      } catch (error) {
+        console.error(`[MissingScenes] Failed to add ${scene.title}:`, error);
+        failed++;
+      }
+
+      // Small delay between requests
+      await new Promise((resolve) => setTimeout(resolve, 500));
+    }
+
+    addAllBtn.classList.remove("ms-btn-loading");
+
+    if (failed === 0) {
+      addAllBtn.textContent = `Added ${added} scenes!`;
+      addAllBtn.classList.add("ms-btn-success");
+      setStatus(`Successfully added ${added} scenes to Whisparr`, "success");
+    } else {
+      addAllBtn.textContent = `Added ${added}, ${failed} failed`;
+      addAllBtn.classList.add("ms-btn-error");
+      setStatus(`Added ${added} scenes, ${failed} failed`, "error");
+    }
+
+    // Hide button after all are added
+    if (failed === 0) {
+      setTimeout(() => {
+        addAllBtn.style.display = "none";
+      }, 3000);
+    } else {
+      addAllBtn.disabled = false;
+    }
+  }
+
+  /**
+   * Set status message
+   */
+  function setStatus(message, type = "") {
+    const statusEl = document.getElementById("ms-status");
+    if (!statusEl) return;
+
+    statusEl.textContent = message;
+    statusEl.className = "ms-status";
+    if (type) {
+      statusEl.classList.add(`ms-status-${type}`);
+    }
+  }
+
+  /**
+   * Show loading state
+   */
+  function showLoading() {
+    const container = document.getElementById("ms-results");
+    if (container) {
+      container.innerHTML = `
+        <div class="ms-placeholder">
+          <div class="ms-spinner"></div>
+          <div>Searching StashDB for missing scenes...</div>
+        </div>
+      `;
+    }
+  }
+
+  /**
+   * Escape HTML to prevent XSS
+   */
+  function escapeHtml(text) {
+    const div = document.createElement("div");
+    div.textContent = text;
+    return div.innerHTML;
+  }
+
+  /**
+   * Show error state
+   */
+  function showError(message) {
+    const container = document.getElementById("ms-results");
+    if (container) {
+      container.innerHTML = `
+        <div class="ms-placeholder ms-error">
+          <div class="ms-error-icon">!</div>
+          <div>${escapeHtml(message)}</div>
+        </div>
+      `;
+    }
+  }
+
+  /**
+   * Handle the search button click
+   */
+  async function handleSearch() {
+    if (isLoading) return;
+    if (!currentEntityId || !currentEntityType) {
+      console.error("[MissingScenes] No entity selected");
+      return;
+    }
+
+    isLoading = true;
+    createModal();
+    showLoading();
+    setStatus("Searching...", "loading");
+
+    try {
+      const result = await findMissingScenes(currentEntityType, currentEntityId);
+
+      missingScenes = result.missing_scenes || [];
+      whisparrConfigured = result.whisparr_configured || false;
+      stashdbUrl = result.stashdb_url || "https://stashdb.org";
+
+      updateStats(result);
+      renderResults();
+
+      if (missingScenes.length > 0) {
+        setStatus(`Found ${missingScenes.length} missing scenes`, "success");
+      } else {
+        setStatus("You have all available scenes!", "success");
+      }
+    } catch (error) {
+      console.error("[MissingScenes] Search failed:", error);
+      showError(error.message || "Failed to search for missing scenes");
+      setStatus(error.message || "Search failed", "error");
+    } finally {
+      isLoading = false;
+    }
+  }
+
+  /**
+   * Create the search button
+   */
+  function createSearchButton() {
+    const btn = document.createElement("button");
+    btn.className = "ms-search-button btn btn-secondary";
+    btn.type = "button";
+    btn.title = "Find scenes from StashDB that you don't have";
+    btn.innerHTML = `
+      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="width: 1em; height: 1em; margin-right: 0.5em;">
+        <circle cx="11" cy="11" r="8"></circle>
+        <line x1="21" y1="21" x2="16.65" y2="16.65"></line>
+        <line x1="8" y1="11" x2="14" y2="11"></line>
+      </svg>
+      Missing Scenes
+    `;
+    btn.onclick = handleSearch;
+    return btn;
+  }
+
+  /**
+   * Check if we're on a performer page
+   */
+  function getPerformerPageInfo() {
+    const match = window.location.pathname.match(/\/performers\/(\d+)/);
+    if (match) {
+      return { type: "performer", id: match[1] };
+    }
+    return null;
+  }
+
+  /**
+   * Check if we're on a studio page
+   */
+  function getStudioPageInfo() {
+    const match = window.location.pathname.match(/\/studios\/(\d+)/);
+    if (match) {
+      return { type: "studio", id: match[1] };
+    }
+    return null;
+  }
+
+  /**
+   * Add the search button to the page
+   */
+  function addSearchButton() {
+    // Check if button already exists
+    if (document.querySelector(".ms-search-button")) {
+      return;
+    }
+
+    // Determine page type
+    const performerInfo = getPerformerPageInfo();
+    const studioInfo = getStudioPageInfo();
+
+    if (!performerInfo && !studioInfo) {
+      return;
+    }
+
+    const entityInfo = performerInfo || studioInfo;
+    currentEntityType = entityInfo.type;
+    currentEntityId = entityInfo.id;
+
+    // Find a place to add the button - use same selectors as Performer Image Search
+    // to ensure buttons appear together
+    const buttonContainer =
+      document.querySelector(".detail-header-buttons") ||
+      document.querySelector('[class*="detail"] [class*="button"]')?.parentElement ||
+      document.querySelector(".performer-head") ||
+      document.querySelector(".studio-head");
+
+    if (!buttonContainer) {
+      // Try again later - page might not be fully loaded
+      return;
+    }
+
+    const searchBtn = createSearchButton();
+    buttonContainer.appendChild(searchBtn);
+  }
+
+  /**
+   * Wait for page to be ready and add button
+   */
+  function waitForPage() {
+    // Check immediately
+    addSearchButton();
+
+    // Also observe for SPA navigation
+    const observer = new MutationObserver(() => {
+      // Small delay to let React finish rendering
+      setTimeout(addSearchButton, 100);
+    });
+
+    observer.observe(document.body, {
+      childList: true,
+      subtree: true,
+    });
+
+    // Also listen to popstate for SPA navigation
+    window.addEventListener("popstate", () => {
+      setTimeout(addSearchButton, 100);
+    });
+  }
+
+  /**
+   * Initialize the plugin
+   */
+  function init() {
+    // Wait for DOM to be ready
+    if (document.readyState === "loading") {
+      document.addEventListener("DOMContentLoaded", waitForPage);
+    } else {
+      waitForPage();
+    }
+  }
+
+  // Start the plugin
+  init();
+})();

--- a/plugins/missingScenes/missingScenes.yml
+++ b/plugins/missingScenes/missingScenes.yml
@@ -1,0 +1,48 @@
+name: Missing Scenes
+description: Discover scenes from StashDB that you don't have locally. View missing scenes for performers and studios, with optional Whisparr integration for automated downloading.
+version: 1.0.0
+url: https://github.com/carrotwaxr/stash-plugins
+
+# UI plugin - injects button and modal on performer/studio pages
+ui:
+  javascript:
+    - missing-scenes.js
+  css:
+    - missing-scenes.css
+
+# Plugin settings configurable in Stash UI (Settings > Plugins)
+# Note: Stash doesn't support YAML defaults. Defaults are handled in code.
+settings:
+  # Stash-box endpoint selection
+  stashBoxEndpoint:
+    displayName: Stash-Box Endpoint
+    description: Which stash-box to query for missing scenes. Leave empty to use the first configured endpoint (usually StashDB). Enter the full GraphQL URL (e.g., https://stashdb.org/graphql).
+    type: STRING
+
+  # Whisparr integration (optional)
+  whisparrUrl:
+    displayName: Whisparr URL
+    description: Optional. URL to your Whisparr instance (e.g., http://localhost:6969). Leave empty to disable Whisparr integration.
+    type: STRING
+  whisparrApiKey:
+    displayName: Whisparr API Key
+    description: Optional. API key for Whisparr (found in Settings > General > Security).
+    type: STRING
+  whisparrQualityProfile:
+    displayName: Whisparr Quality Profile ID
+    description: Optional. Quality profile ID to use when adding scenes (default is 1). Find IDs in Whisparr Settings > Profiles.
+    type: NUMBER
+  whisparrRootFolder:
+    displayName: Whisparr Root Folder
+    description: Optional. Root folder path for downloaded scenes (e.g., /data/videos). Must match a root folder configured in Whisparr.
+    type: STRING
+  whisparrSearchOnAdd:
+    displayName: Search on Add
+    description: Automatically search for scenes when adding to Whisparr. Enabled by default.
+    type: BOOLEAN
+
+# Python backend for StashDB queries (called via runPluginOperation from JS)
+exec:
+  - python
+  - "{pluginDir}/missing_scenes.py"
+interface: raw

--- a/plugins/missingScenes/missing_scenes.py
+++ b/plugins/missingScenes/missing_scenes.py
@@ -1,0 +1,858 @@
+#!/usr/bin/env python3
+"""
+Missing Scenes - StashDB Scene Discovery Backend
+Discovers scenes from StashDB that you don't have locally.
+Supports performers and studios with optional Whisparr integration.
+
+Uses only Python standard library - no pip dependencies.
+"""
+
+import json
+import sys
+import urllib.request
+import urllib.parse
+import urllib.error
+import ssl
+
+# Import Stash-compatible logging
+import log
+
+# Create SSL context that doesn't verify certificates (for self-signed certs)
+SSL_CONTEXT = ssl.create_default_context()
+SSL_CONTEXT.check_hostname = False
+SSL_CONTEXT.verify_mode = ssl.CERT_NONE
+
+
+# ============================================================================
+# GraphQL Helpers
+# ============================================================================
+
+def graphql_request(url, query, variables=None, api_key=None, timeout=30):
+    """Make a GraphQL request to the specified endpoint."""
+    headers = {
+        "Content-Type": "application/json",
+        "Accept": "application/json",
+    }
+
+    if api_key:
+        headers["ApiKey"] = api_key
+
+    data = json.dumps({
+        "query": query,
+        "variables": variables or {}
+    }).encode("utf-8")
+
+    req = urllib.request.Request(url, data=data, headers=headers, method="POST")
+
+    try:
+        with urllib.request.urlopen(req, timeout=timeout, context=SSL_CONTEXT) as response:
+            result = json.loads(response.read().decode("utf-8"))
+            if "errors" in result:
+                log.LogWarning(f"GraphQL errors: {result['errors']}")
+            return result.get("data")
+    except urllib.error.HTTPError as e:
+        log.LogError(f"HTTP error {e.code}: {e.reason}")
+        raise
+    except urllib.error.URLError as e:
+        log.LogError(f"URL error: {e.reason}")
+        raise
+    except Exception as e:
+        log.LogError(f"Request error: {e}")
+        raise
+
+
+# ============================================================================
+# Local Stash API
+# ============================================================================
+
+# Global to cache the connection info (stdin can only be read once)
+_stash_connection = None
+_input_data = None
+
+
+def get_stash_connection():
+    """Get Stash connection details from plugin input."""
+    global _stash_connection, _input_data
+
+    if _stash_connection is not None:
+        return _stash_connection
+
+    # These are passed by the Stash plugin system
+    try:
+        if _input_data is None:
+            _input_data = json.loads(sys.stdin.read())
+        server_connection = _input_data.get("server_connection", {})
+        _stash_connection = {
+            "url": server_connection.get("Scheme", "http") + "://" +
+                   server_connection.get("Host", "localhost") + ":" +
+                   str(server_connection.get("Port", 9999)) + "/graphql",
+            "api_key": server_connection.get("SessionCookie", {}).get("Value"),
+        }
+        return _stash_connection
+    except Exception as e:
+        log.LogError(f"Failed to get Stash connection: {e}")
+        _stash_connection = {"url": "http://localhost:9999/graphql", "api_key": None}
+        return _stash_connection
+
+
+def get_input_data():
+    """Get the full input data from stdin (cached)."""
+    global _input_data
+    if _input_data is None:
+        _input_data = json.loads(sys.stdin.read())
+    return _input_data
+
+
+def stash_graphql(query, variables=None):
+    """Make a GraphQL request to local Stash instance."""
+    conn = get_stash_connection()
+    headers = {
+        "Content-Type": "application/json",
+        "Accept": "application/json",
+    }
+
+    # Use session cookie if available
+    if conn.get("api_key"):
+        headers["Cookie"] = f"session={conn['api_key']}"
+
+    data = json.dumps({
+        "query": query,
+        "variables": variables or {}
+    }).encode("utf-8")
+
+    req = urllib.request.Request(conn["url"], data=data, headers=headers, method="POST")
+
+    try:
+        with urllib.request.urlopen(req, timeout=30, context=SSL_CONTEXT) as response:
+            result = json.loads(response.read().decode("utf-8"))
+            if "errors" in result:
+                log.LogWarning(f"Stash GraphQL errors: {result['errors']}")
+            return result.get("data")
+    except Exception as e:
+        log.LogError(f"Stash request error: {e}")
+        raise
+
+
+def get_stashbox_config():
+    """Get configured stash-box endpoints from Stash settings."""
+    query = """
+    query Configuration {
+        configuration {
+            general {
+                stashBoxes {
+                    endpoint
+                    api_key
+                    name
+                }
+            }
+        }
+    }
+    """
+    data = stash_graphql(query)
+    if data and "configuration" in data:
+        return data["configuration"]["general"].get("stashBoxes", [])
+    return []
+
+
+def get_local_performer(performer_id):
+    """Get a performer from local Stash with their stash_ids."""
+    query = """
+    query FindPerformer($id: ID!) {
+        findPerformer(id: $id) {
+            id
+            name
+            stash_ids {
+                endpoint
+                stash_id
+            }
+        }
+    }
+    """
+    data = stash_graphql(query, {"id": performer_id})
+    if data:
+        return data.get("findPerformer")
+    return None
+
+
+def get_local_studio(studio_id):
+    """Get a studio from local Stash with their stash_ids."""
+    query = """
+    query FindStudio($id: ID!) {
+        findStudio(id: $id) {
+            id
+            name
+            stash_ids {
+                endpoint
+                stash_id
+            }
+        }
+    }
+    """
+    data = stash_graphql(query, {"id": studio_id})
+    if data:
+        return data.get("findStudio")
+    return None
+
+
+def get_local_scene_stash_ids(endpoint):
+    """Get all stash_ids for scenes that are linked to a specific stash-box endpoint."""
+    # Get all scenes with stash_ids
+    query = """
+    query FindScenes($filter: FindFilterType) {
+        findScenes(filter: $filter) {
+            count
+            scenes {
+                id
+                stash_ids {
+                    endpoint
+                    stash_id
+                }
+            }
+        }
+    }
+    """
+
+    all_stash_ids = set()
+    page = 1
+    per_page = 100
+
+    while True:
+        data = stash_graphql(query, {
+            "filter": {
+                "page": page,
+                "per_page": per_page
+            }
+        })
+
+        if not data or "findScenes" not in data:
+            break
+
+        scenes = data["findScenes"].get("scenes", [])
+        if not scenes:
+            break
+
+        for scene in scenes:
+            for stash_id in scene.get("stash_ids", []):
+                if stash_id.get("endpoint") == endpoint:
+                    all_stash_ids.add(stash_id.get("stash_id"))
+
+        # Check if we've gotten all scenes
+        total = data["findScenes"].get("count", 0)
+        if page * per_page >= total:
+            break
+
+        page += 1
+
+    log.LogInfo(f"Found {len(all_stash_ids)} local scenes linked to {endpoint}")
+    return all_stash_ids
+
+
+# ============================================================================
+# StashDB API
+# ============================================================================
+
+def query_stashdb_performer_scenes(stashdb_url, api_key, performer_stash_id, max_pages=10):
+    """Query StashDB for all scenes featuring a performer using paginated queryScenes."""
+    # First get the performer name for logging
+    name_query = """
+    query FindPerformer($id: ID!) {
+        findPerformer(id: $id) {
+            name
+        }
+    }
+    """
+    name_data = graphql_request(stashdb_url, name_query, {"id": performer_stash_id}, api_key)
+    performer_name = "Unknown"
+    if name_data and "findPerformer" in name_data:
+        performer_name = name_data["findPerformer"].get("name", "Unknown")
+
+    # Use queryScenes with performer filter for proper pagination
+    query = """
+    query QueryScenes($input: SceneQueryInput!) {
+        queryScenes(input: $input) {
+            count
+            scenes {
+                id
+                title
+                details
+                release_date
+                duration
+                code
+                director
+                urls {
+                    url
+                    site {
+                        name
+                    }
+                }
+                studio {
+                    id
+                    name
+                }
+                images {
+                    id
+                    url
+                    width
+                    height
+                }
+                performers {
+                    performer {
+                        id
+                        name
+                        disambiguation
+                        gender
+                    }
+                    as
+                }
+            }
+        }
+    }
+    """
+
+    all_scenes = []
+    page = 1
+    per_page = 100
+
+    while page <= max_pages:
+        variables = {
+            "input": {
+                "performers": {
+                    "value": [performer_stash_id],
+                    "modifier": "INCLUDES"
+                },
+                "page": page,
+                "per_page": per_page,
+                "sort": "DATE",
+                "direction": "DESC"
+            }
+        }
+
+        data = graphql_request(stashdb_url, query, variables, api_key)
+        if not data or "queryScenes" not in data:
+            break
+
+        scenes = data["queryScenes"].get("scenes", [])
+        if not scenes:
+            break
+
+        all_scenes.extend(scenes)
+
+        total = data["queryScenes"].get("count", 0)
+        log.LogInfo(f"StashDB: Fetched page {page}, {len(scenes)} scenes (total: {total})")
+
+        if page * per_page >= total:
+            break
+
+        page += 1
+
+    log.LogInfo(f"StashDB: Found {len(all_scenes)} scenes for {performer_name}")
+    return all_scenes
+
+
+def query_stashdb_studio_scenes(stashdb_url, api_key, studio_stash_id, max_pages=10):
+    """Query StashDB for all scenes from a studio."""
+    query = """
+    query QueryScenes($input: SceneQueryInput!) {
+        queryScenes(input: $input) {
+            count
+            scenes {
+                id
+                title
+                details
+                release_date
+                duration
+                code
+                director
+                urls {
+                    url
+                    site {
+                        name
+                    }
+                }
+                studio {
+                    id
+                    name
+                }
+                images {
+                    id
+                    url
+                    width
+                    height
+                }
+                performers {
+                    performer {
+                        id
+                        name
+                        disambiguation
+                        gender
+                    }
+                    as
+                }
+            }
+        }
+    }
+    """
+
+    all_scenes = []
+    page = 1
+    per_page = 100
+
+    while page <= max_pages:
+        variables = {
+            "input": {
+                "studios": {
+                    "value": [studio_stash_id],
+                    "modifier": "INCLUDES"
+                },
+                "page": page,
+                "per_page": per_page,
+                "sort": "TRENDING",  # Use TRENDING for popularity-based sorting
+                "direction": "DESC"
+            }
+        }
+
+        data = graphql_request(stashdb_url, query, variables, api_key)
+        if not data or "queryScenes" not in data:
+            break
+
+        scenes = data["queryScenes"].get("scenes", [])
+        if not scenes:
+            break
+
+        all_scenes.extend(scenes)
+
+        total = data["queryScenes"].get("count", 0)
+        log.LogInfo(f"StashDB: Fetched page {page}, {len(scenes)} scenes (total: {total})")
+
+        if page * per_page >= total:
+            break
+
+        page += 1
+
+    log.LogInfo(f"StashDB: Found {len(all_scenes)} total scenes for studio")
+    return all_scenes
+
+
+# ============================================================================
+# Whisparr API
+# ============================================================================
+
+def whisparr_request(whisparr_url, api_key, endpoint, method="GET", payload=None):
+    """Make a request to the Whisparr API."""
+    url = f"{whisparr_url.rstrip('/')}/api/v3/{endpoint}"
+    headers = {
+        "X-Api-Key": api_key,
+        "Content-Type": "application/json",
+        "Accept": "application/json",
+    }
+
+    data = None
+    if payload:
+        data = json.dumps(payload).encode("utf-8")
+
+    req = urllib.request.Request(url, data=data, headers=headers, method=method)
+
+    try:
+        with urllib.request.urlopen(req, timeout=30, context=SSL_CONTEXT) as response:
+            return json.loads(response.read().decode("utf-8"))
+    except urllib.error.HTTPError as e:
+        body = e.read().decode("utf-8") if e.fp else ""
+        log.LogError(f"Whisparr HTTP error {e.code}: {e.reason} - {body}")
+        raise
+    except Exception as e:
+        log.LogError(f"Whisparr request error: {e}")
+        raise
+
+
+def whisparr_lookup_scene(whisparr_url, api_key, stash_id):
+    """Lookup a scene in Whisparr by its StashDB ID."""
+    try:
+        # Use the lookup endpoint to search by stash ID
+        endpoint = f"lookup/scene?term=stash:{urllib.parse.quote(stash_id)}"
+        result = whisparr_request(whisparr_url, api_key, endpoint)
+        if result and len(result) > 0:
+            return result[0].get("movie")
+        return None
+    except Exception as e:
+        log.LogWarning(f"Whisparr lookup failed for {stash_id}: {e}")
+        return None
+
+
+def whisparr_add_scene(whisparr_url, api_key, scene_data, quality_profile_id, root_folder, search_on_add=True):
+    """Add a scene to Whisparr."""
+    payload = {
+        "foreignId": f"stash:{scene_data['stash_id']}",
+        "title": scene_data.get("title", "Unknown"),
+        "rootFolderPath": root_folder,
+        "qualityProfileId": quality_profile_id,
+        "monitored": True,
+        "tags": [],
+        "addOptions": {
+            "searchForMovie": search_on_add
+        }
+    }
+
+    try:
+        result = whisparr_request(whisparr_url, api_key, "movie", "POST", payload)
+        log.LogInfo(f"Added scene to Whisparr: {scene_data.get('title')}")
+        return result
+    except Exception as e:
+        log.LogError(f"Failed to add scene to Whisparr: {e}")
+        raise
+
+
+def whisparr_get_existing_stash_ids(whisparr_url, api_key):
+    """Get all StashDB IDs already in Whisparr."""
+    stash_ids = set()
+    page = 1
+    per_page = 100
+
+    while True:
+        try:
+            endpoint = f"movie?page={page}&pageSize={per_page}"
+            result = whisparr_request(whisparr_url, api_key, endpoint)
+
+            if not result:
+                break
+
+            # Handle both list response and paginated response
+            if isinstance(result, list):
+                scenes = result
+            else:
+                scenes = result.get("records", result)
+
+            if not scenes:
+                break
+
+            for scene in scenes:
+                foreign_id = scene.get("foreignId", "")
+                if foreign_id.startswith("stash:"):
+                    stash_ids.add(foreign_id.replace("stash:", ""))
+
+            # If we got fewer results than requested, we're done
+            if len(scenes) < per_page:
+                break
+
+            page += 1
+
+        except Exception as e:
+            log.LogWarning(f"Error fetching Whisparr scenes page {page}: {e}")
+            break
+
+    log.LogInfo(f"Found {len(stash_ids)} scenes in Whisparr")
+    return stash_ids
+
+
+# ============================================================================
+# Main Operations
+# ============================================================================
+
+def find_missing_scenes(entity_type, entity_id, plugin_settings):
+    """
+    Find scenes from StashDB that are not in local Stash.
+
+    Args:
+        entity_type: "performer" or "studio"
+        entity_id: Local Stash ID of the performer/studio
+        plugin_settings: Plugin configuration from Stash
+
+    Returns:
+        Dict with missing scenes and metadata
+    """
+
+    # Get stash-box configuration
+    stashbox_configs = get_stashbox_config()
+    if not stashbox_configs:
+        return {"error": "No stash-box endpoints configured in Stash settings"}
+
+    # Check if user specified a preferred endpoint
+    preferred_endpoint = plugin_settings.get("stashBoxEndpoint", "").strip()
+
+    # Find the matching stash-box config
+    stashbox = None
+    if preferred_endpoint:
+        # User specified an endpoint - find it
+        for config in stashbox_configs:
+            if config["endpoint"] == preferred_endpoint:
+                stashbox = config
+                break
+        if not stashbox:
+            # Endpoint not found in configured list
+            available = ", ".join([c.get("name", c["endpoint"]) for c in stashbox_configs])
+            return {"error": f"Configured stash-box endpoint '{preferred_endpoint}' not found. Available: {available}"}
+    else:
+        # Use the first stash-box (usually StashDB)
+        stashbox = stashbox_configs[0]
+
+    stashdb_url = stashbox["endpoint"]
+    stashdb_api_key = stashbox.get("api_key", "")
+    stashdb_name = stashbox.get("name", "StashDB")
+
+    log.LogInfo(f"Using stash-box: {stashdb_name} ({stashdb_url})")
+
+    # Get the local entity and its stash_id
+    if entity_type == "performer":
+        entity = get_local_performer(entity_id)
+    elif entity_type == "studio":
+        entity = get_local_studio(entity_id)
+    else:
+        return {"error": f"Unknown entity type: {entity_type}"}
+
+    if not entity:
+        return {"error": f"{entity_type.title()} not found: {entity_id}"}
+
+    # Find the stash_id for this stash-box endpoint
+    stash_id = None
+    for sid in entity.get("stash_ids", []):
+        if sid.get("endpoint") == stashdb_url:
+            stash_id = sid.get("stash_id")
+            break
+
+    if not stash_id:
+        return {
+            "error": f"{entity_type.title()} '{entity.get('name')}' is not linked to {stashdb_name}. "
+                     f"Please use the Tagger to link this {entity_type} first."
+        }
+
+    log.LogInfo(f"Found {entity_type} '{entity.get('name')}' with StashDB ID: {stash_id}")
+
+    # Query StashDB for all scenes
+    if entity_type == "performer":
+        stashdb_scenes = query_stashdb_performer_scenes(stashdb_url, stashdb_api_key, stash_id)
+    else:
+        stashdb_scenes = query_stashdb_studio_scenes(stashdb_url, stashdb_api_key, stash_id)
+
+    if not stashdb_scenes:
+        return {
+            "entity_name": entity.get("name"),
+            "entity_type": entity_type,
+            "stashdb_name": stashdb_name,
+            "total_on_stashdb": 0,
+            "total_local": 0,
+            "missing_count": 0,
+            "missing_scenes": []
+        }
+
+    # Get all local scene stash_ids
+    local_stash_ids = get_local_scene_stash_ids(stashdb_url)
+
+    # Also check Whisparr if configured
+    whisparr_stash_ids = set()
+    whisparr_configured = False
+    whisparr_url = plugin_settings.get("whisparrUrl", "")
+    whisparr_api_key = plugin_settings.get("whisparrApiKey", "")
+
+    if whisparr_url and whisparr_api_key:
+        whisparr_configured = True
+        try:
+            whisparr_stash_ids = whisparr_get_existing_stash_ids(whisparr_url, whisparr_api_key)
+        except Exception as e:
+            log.LogWarning(f"Could not fetch Whisparr scenes: {e}")
+
+    # Find missing scenes
+    missing_scenes = []
+    for scene in stashdb_scenes:
+        scene_stash_id = scene.get("id")
+        if scene_stash_id not in local_stash_ids:
+            # Format the scene data
+            formatted = format_scene(scene, scene_stash_id)
+
+            # Mark if it's in Whisparr
+            formatted["in_whisparr"] = scene_stash_id in whisparr_stash_ids
+
+            missing_scenes.append(formatted)
+
+    # Sort by release date (newest first)
+    # Note: For studio queries, StashDB returns results sorted by TRENDING (popularity),
+    # but we re-sort by date here for consistency. For performer queries, scenes come
+    # back unsorted from StashDB's findPerformer endpoint.
+    missing_scenes.sort(key=lambda s: s.get("release_date") or "", reverse=True)
+
+    log.LogInfo(f"Found {len(missing_scenes)} missing scenes out of {len(stashdb_scenes)} total")
+
+    return {
+        "entity_name": entity.get("name"),
+        "entity_type": entity_type,
+        "stashdb_name": stashdb_name,
+        "stashdb_url": stashdb_url.replace("/graphql", ""),
+        "total_on_stashdb": len(stashdb_scenes),
+        "total_local": len(stashdb_scenes) - len(missing_scenes),
+        "missing_count": len(missing_scenes),
+        "missing_scenes": missing_scenes,
+        "whisparr_configured": whisparr_configured
+    }
+
+
+def format_scene(scene, stash_id):
+    """Format a StashDB scene for the frontend."""
+    # Get the best image (prefer landscape for thumbnails)
+    images = scene.get("images", [])
+    thumbnail = None
+    if images:
+        # Try to find a landscape image first
+        for img in images:
+            if img.get("width", 0) > img.get("height", 0):
+                thumbnail = img.get("url")
+                break
+        if not thumbnail:
+            thumbnail = images[0].get("url")
+
+    # Format performers
+    performers = []
+    for perf in scene.get("performers", []):
+        p = perf.get("performer", {})
+        performers.append({
+            "id": p.get("id"),
+            "name": p.get("name"),
+            "disambiguation": p.get("disambiguation"),
+            "gender": p.get("gender"),
+            "as": perf.get("as")
+        })
+
+    # Get studio
+    studio = scene.get("studio")
+    studio_info = None
+    if studio:
+        studio_info = {
+            "id": studio.get("id"),
+            "name": studio.get("name")
+        }
+
+    # Get primary URL
+    urls = scene.get("urls", [])
+    primary_url = urls[0].get("url") if urls else None
+
+    return {
+        "stash_id": stash_id,
+        "title": scene.get("title") or "Unknown Title",
+        "details": scene.get("details"),
+        "release_date": scene.get("release_date"),
+        "duration": scene.get("duration"),
+        "code": scene.get("code"),
+        "director": scene.get("director"),
+        "thumbnail": thumbnail,
+        "studio": studio_info,
+        "performers": performers,
+        "url": primary_url
+    }
+
+
+def add_to_whisparr(stash_id, title, plugin_settings):
+    """Add a scene to Whisparr by its StashDB ID."""
+    whisparr_url = plugin_settings.get("whisparrUrl", "")
+    whisparr_api_key = plugin_settings.get("whisparrApiKey", "")
+    quality_profile = int(plugin_settings.get("whisparrQualityProfile") or 1)
+    root_folder = plugin_settings.get("whisparrRootFolder", "")
+    search_on_add = plugin_settings.get("whisparrSearchOnAdd", True)
+
+    if not whisparr_url or not whisparr_api_key:
+        return {"error": "Whisparr is not configured. Please set URL and API key in plugin settings."}
+
+    if not root_folder:
+        return {"error": "Whisparr root folder is not configured. Please set it in plugin settings."}
+
+    try:
+        # First lookup the scene to get full details
+        scene = whisparr_lookup_scene(whisparr_url, whisparr_api_key, stash_id)
+
+        if not scene:
+            return {"error": f"Scene not found in Whisparr lookup. It may not be available for download yet."}
+
+        # Add the scene
+        result = whisparr_add_scene(
+            whisparr_url,
+            whisparr_api_key,
+            {"stash_id": stash_id, "title": title},
+            quality_profile,
+            root_folder,
+            search_on_add
+        )
+
+        return {
+            "success": True,
+            "message": f"Added '{title}' to Whisparr",
+            "scene": result
+        }
+
+    except Exception as e:
+        return {"error": str(e)}
+
+
+# ============================================================================
+# Plugin Entry Point
+# ============================================================================
+
+def main():
+    """Main entry point for the plugin."""
+
+    # Read input from stdin (uses cached version to avoid double-read issue)
+    try:
+        input_data = get_input_data()
+    except json.JSONDecodeError as e:
+        output = {"error": f"Invalid JSON input: {e}"}
+        print(json.dumps(output))
+        return
+
+    # Get the operation arguments
+    args = input_data.get("args", {})
+    operation = args.get("operation", "")
+
+    # Get plugin settings
+    server_connection = input_data.get("server_connection", {})
+    plugin_settings = {}
+
+    # Try to get plugin settings from the configuration
+    try:
+        config_data = stash_graphql("""
+            query Configuration {
+                configuration {
+                    plugins
+                }
+            }
+        """)
+        if config_data and "configuration" in config_data:
+            plugins_config = config_data["configuration"].get("plugins", {})
+            plugin_settings = plugins_config.get("missingScenes", {})
+    except Exception as e:
+        log.LogWarning(f"Could not load plugin settings: {e}")
+
+    output = {"error": "Unknown operation"}
+
+    try:
+        if operation == "find_missing":
+            entity_type = args.get("entity_type", "performer")
+            entity_id = args.get("entity_id", "")
+
+            if not entity_id:
+                output = {"error": "entity_id is required"}
+            else:
+                output = find_missing_scenes(entity_type, entity_id, plugin_settings)
+
+        elif operation == "add_to_whisparr":
+            stash_id = args.get("stash_id", "")
+            title = args.get("title", "Unknown")
+
+            if not stash_id:
+                output = {"error": "stash_id is required"}
+            else:
+                output = add_to_whisparr(stash_id, title, plugin_settings)
+
+        else:
+            output = {"error": f"Unknown operation: {operation}"}
+
+    except Exception as e:
+        log.LogError(f"Operation failed: {e}")
+        output = {"error": str(e)}
+
+    # Wrap output in PluginOutput structure expected by Stash
+    # Structure: {"output": <data>} or {"error": "message"}
+    if "error" in output:
+        plugin_output = {"error": output["error"]}
+    else:
+        plugin_output = {"output": output}
+
+    print(json.dumps(plugin_output))
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/missingScenes/test_missing_scenes.py
+++ b/plugins/missingScenes/test_missing_scenes.py
@@ -1,0 +1,483 @@
+#!/usr/bin/env python3
+"""
+Tests for Missing Scenes plugin.
+Run with: python test_missing_scenes.py
+
+Tests verify:
+1. Scene formatting logic
+2. Whisparr payload building
+3. URL construction
+4. Error handling
+"""
+
+import sys
+import json
+import unittest
+from unittest.mock import patch, MagicMock
+
+# Import the module to test
+import missing_scenes
+
+
+class TestFormatScene(unittest.TestCase):
+    """Test the format_scene function."""
+
+    def test_basic_scene(self):
+        """Test formatting a basic scene with minimal data."""
+        scene = {
+            "id": "abc123",
+            "title": "Test Scene",
+            "release_date": "2024-01-15",
+            "duration": 1800,
+            "images": [],
+            "performers": [],
+            "urls": [],
+            "studio": None,
+        }
+
+        result = missing_scenes.format_scene(scene, "abc123")
+
+        self.assertEqual(result["stash_id"], "abc123")
+        self.assertEqual(result["title"], "Test Scene")
+        self.assertEqual(result["release_date"], "2024-01-15")
+        self.assertEqual(result["duration"], 1800)
+        self.assertIsNone(result["thumbnail"])
+        self.assertEqual(result["performers"], [])
+        self.assertIsNone(result["studio"])
+
+    def test_scene_with_thumbnail(self):
+        """Test that thumbnail is extracted correctly."""
+        scene = {
+            "id": "abc123",
+            "title": "Test Scene",
+            "images": [
+                {"id": "img1", "url": "http://example.com/thumb.jpg", "width": 800, "height": 600},
+            ],
+            "performers": [],
+            "urls": [],
+            "studio": None,
+        }
+
+        result = missing_scenes.format_scene(scene, "abc123")
+
+        self.assertEqual(result["thumbnail"], "http://example.com/thumb.jpg")
+
+    def test_scene_prefers_landscape_thumbnail(self):
+        """Test that landscape images are preferred for thumbnails."""
+        scene = {
+            "id": "abc123",
+            "title": "Test Scene",
+            "images": [
+                {"id": "img1", "url": "http://example.com/portrait.jpg", "width": 600, "height": 800},
+                {"id": "img2", "url": "http://example.com/landscape.jpg", "width": 1920, "height": 1080},
+            ],
+            "performers": [],
+            "urls": [],
+            "studio": None,
+        }
+
+        result = missing_scenes.format_scene(scene, "abc123")
+
+        self.assertEqual(result["thumbnail"], "http://example.com/landscape.jpg")
+
+    def test_scene_with_performers(self):
+        """Test performer formatting."""
+        scene = {
+            "id": "abc123",
+            "title": "Test Scene",
+            "images": [],
+            "performers": [
+                {
+                    "performer": {
+                        "id": "perf1",
+                        "name": "Jane Doe",
+                        "disambiguation": None,
+                        "gender": "FEMALE",
+                    },
+                    "as": None,
+                },
+                {
+                    "performer": {
+                        "id": "perf2",
+                        "name": "John Smith",
+                        "disambiguation": "actor",
+                        "gender": "MALE",
+                    },
+                    "as": "Johnny",
+                },
+            ],
+            "urls": [],
+            "studio": None,
+        }
+
+        result = missing_scenes.format_scene(scene, "abc123")
+
+        self.assertEqual(len(result["performers"]), 2)
+        self.assertEqual(result["performers"][0]["name"], "Jane Doe")
+        self.assertEqual(result["performers"][0]["gender"], "FEMALE")
+        self.assertEqual(result["performers"][1]["name"], "John Smith")
+        self.assertEqual(result["performers"][1]["as"], "Johnny")
+
+    def test_scene_with_studio(self):
+        """Test studio formatting."""
+        scene = {
+            "id": "abc123",
+            "title": "Test Scene",
+            "images": [],
+            "performers": [],
+            "urls": [],
+            "studio": {
+                "id": "studio1",
+                "name": "Test Studio",
+            },
+        }
+
+        result = missing_scenes.format_scene(scene, "abc123")
+
+        self.assertEqual(result["studio"]["id"], "studio1")
+        self.assertEqual(result["studio"]["name"], "Test Studio")
+
+    def test_scene_with_url(self):
+        """Test URL extraction."""
+        scene = {
+            "id": "abc123",
+            "title": "Test Scene",
+            "images": [],
+            "performers": [],
+            "urls": [
+                {"url": "http://example.com/scene1", "site": {"name": "Example"}},
+            ],
+            "studio": None,
+        }
+
+        result = missing_scenes.format_scene(scene, "abc123")
+
+        self.assertEqual(result["url"], "http://example.com/scene1")
+
+    def test_scene_missing_title(self):
+        """Test that missing title defaults to 'Unknown Title'."""
+        scene = {
+            "id": "abc123",
+            "title": None,
+            "images": [],
+            "performers": [],
+            "urls": [],
+            "studio": None,
+        }
+
+        result = missing_scenes.format_scene(scene, "abc123")
+
+        self.assertEqual(result["title"], "Unknown Title")
+
+    def test_scene_empty_title(self):
+        """Test that empty title defaults to 'Unknown Title'."""
+        scene = {
+            "id": "abc123",
+            "title": "",
+            "images": [],
+            "performers": [],
+            "urls": [],
+            "studio": None,
+        }
+
+        result = missing_scenes.format_scene(scene, "abc123")
+
+        self.assertEqual(result["title"], "Unknown Title")
+
+
+class TestWhisparrPayload(unittest.TestCase):
+    """Test Whisparr-related functions."""
+
+    def test_whisparr_request_url_construction(self):
+        """Test that Whisparr URLs are constructed correctly."""
+        # Test URL with trailing slash
+        url_with_slash = "http://localhost:6969/"
+        expected = "http://localhost:6969/api/v3/test"
+        actual = f"{url_with_slash.rstrip('/')}/api/v3/test"
+        self.assertEqual(actual, expected)
+
+        # Test URL without trailing slash
+        url_no_slash = "http://localhost:6969"
+        actual = f"{url_no_slash.rstrip('/')}/api/v3/test"
+        self.assertEqual(actual, expected)
+
+    def test_foreign_id_format(self):
+        """Test that foreign IDs are formatted correctly for Whisparr."""
+        stash_id = "abc123-def456"
+        foreign_id = f"stash:{stash_id}"
+        self.assertEqual(foreign_id, "stash:abc123-def456")
+
+
+class TestStashIdMatching(unittest.TestCase):
+    """Test scene matching logic."""
+
+    def test_scene_in_local_stash(self):
+        """Test that scenes in local Stash are correctly identified."""
+        local_ids = {"scene1", "scene2", "scene3"}
+        stashdb_scene_id = "scene2"
+
+        self.assertIn(stashdb_scene_id, local_ids)
+
+    def test_scene_not_in_local_stash(self):
+        """Test that missing scenes are correctly identified."""
+        local_ids = {"scene1", "scene2", "scene3"}
+        stashdb_scene_id = "scene4"
+
+        self.assertNotIn(stashdb_scene_id, local_ids)
+
+    def test_missing_scene_calculation(self):
+        """Test the missing scenes calculation logic."""
+        stashdb_scenes = [
+            {"id": "scene1"},
+            {"id": "scene2"},
+            {"id": "scene3"},
+            {"id": "scene4"},
+        ]
+        local_stash_ids = {"scene1", "scene3"}
+
+        missing = [s for s in stashdb_scenes if s["id"] not in local_stash_ids]
+
+        self.assertEqual(len(missing), 2)
+        self.assertEqual(missing[0]["id"], "scene2")
+        self.assertEqual(missing[1]["id"], "scene4")
+
+
+class TestErrorHandling(unittest.TestCase):
+    """Test error handling."""
+
+    def test_missing_entity_id(self):
+        """Test that missing entity_id returns error."""
+        # Simulate the check in find_missing_scenes
+        entity_id = ""
+        if not entity_id:
+            result = {"error": "entity_id is required"}
+        else:
+            result = {"success": True}
+
+        self.assertIn("error", result)
+        self.assertEqual(result["error"], "entity_id is required")
+
+    def test_unknown_entity_type(self):
+        """Test that unknown entity type returns error."""
+        entity_type = "unknown"
+        valid_types = ["performer", "studio"]
+
+        if entity_type not in valid_types:
+            result = {"error": f"Unknown entity type: {entity_type}"}
+        else:
+            result = {"success": True}
+
+        self.assertIn("error", result)
+
+    def test_no_stashbox_config(self):
+        """Test that missing stash-box config returns error."""
+        stashbox_configs = []
+
+        if not stashbox_configs:
+            result = {"error": "No stash-box endpoints configured in Stash settings"}
+        else:
+            result = {"success": True}
+
+        self.assertIn("error", result)
+
+
+class TestSceneSorting(unittest.TestCase):
+    """Test scene sorting."""
+
+    def test_sort_by_release_date_descending(self):
+        """Test that scenes are sorted by release date (newest first)."""
+        scenes = [
+            {"stash_id": "1", "release_date": "2023-01-01"},
+            {"stash_id": "2", "release_date": "2024-06-15"},
+            {"stash_id": "3", "release_date": "2024-01-01"},
+            {"stash_id": "4", "release_date": None},
+        ]
+
+        # Sort by release_date descending (None values sort last)
+        sorted_scenes = sorted(scenes, key=lambda s: s.get("release_date") or "", reverse=True)
+
+        self.assertEqual(sorted_scenes[0]["stash_id"], "2")  # 2024-06-15
+        self.assertEqual(sorted_scenes[1]["stash_id"], "3")  # 2024-01-01
+        self.assertEqual(sorted_scenes[2]["stash_id"], "1")  # 2023-01-01
+        self.assertEqual(sorted_scenes[3]["stash_id"], "4")  # None
+
+
+class TestGraphQLQueryConstruction(unittest.TestCase):
+    """Test GraphQL query construction."""
+
+    def test_performer_query_has_required_fields(self):
+        """Verify performer query includes all needed fields."""
+        query = """
+        query FindPerformer($id: ID!) {
+            findPerformer(id: $id) {
+                id
+                name
+                stash_ids {
+                    endpoint
+                    stash_id
+                }
+            }
+        }
+        """
+
+        self.assertIn("findPerformer", query)
+        self.assertIn("stash_ids", query)
+        self.assertIn("endpoint", query)
+        self.assertIn("stash_id", query)
+
+    def test_studio_query_has_required_fields(self):
+        """Verify studio query includes all needed fields."""
+        query = """
+        query FindStudio($id: ID!) {
+            findStudio(id: $id) {
+                id
+                name
+                stash_ids {
+                    endpoint
+                    stash_id
+                }
+            }
+        }
+        """
+
+        self.assertIn("findStudio", query)
+        self.assertIn("stash_ids", query)
+
+
+class TestEndpointSelection(unittest.TestCase):
+    """Test stash-box endpoint selection logic."""
+
+    def test_select_preferred_endpoint(self):
+        """Test that preferred endpoint is selected when configured."""
+        stashbox_configs = [
+            {"endpoint": "https://stashdb.org/graphql", "api_key": "key1", "name": "StashDB"},
+            {"endpoint": "https://fansdb.cc/graphql", "api_key": "key2", "name": "FansDB"},
+        ]
+        preferred_endpoint = "https://fansdb.cc/graphql"
+
+        stashbox = None
+        if preferred_endpoint:
+            for config in stashbox_configs:
+                if config["endpoint"] == preferred_endpoint:
+                    stashbox = config
+                    break
+
+        self.assertIsNotNone(stashbox)
+        self.assertEqual(stashbox["name"], "FansDB")
+        self.assertEqual(stashbox["api_key"], "key2")
+
+    def test_fallback_to_first_endpoint(self):
+        """Test that first endpoint is used when no preference set."""
+        stashbox_configs = [
+            {"endpoint": "https://stashdb.org/graphql", "api_key": "key1", "name": "StashDB"},
+            {"endpoint": "https://fansdb.cc/graphql", "api_key": "key2", "name": "FansDB"},
+        ]
+        preferred_endpoint = ""
+
+        stashbox = None
+        if preferred_endpoint:
+            for config in stashbox_configs:
+                if config["endpoint"] == preferred_endpoint:
+                    stashbox = config
+                    break
+        else:
+            stashbox = stashbox_configs[0]
+
+        self.assertEqual(stashbox["name"], "StashDB")
+
+    def test_invalid_endpoint_not_found(self):
+        """Test that invalid endpoint returns None."""
+        stashbox_configs = [
+            {"endpoint": "https://stashdb.org/graphql", "api_key": "key1", "name": "StashDB"},
+        ]
+        preferred_endpoint = "https://invalid.com/graphql"
+
+        stashbox = None
+        if preferred_endpoint:
+            for config in stashbox_configs:
+                if config["endpoint"] == preferred_endpoint:
+                    stashbox = config
+                    break
+
+        self.assertIsNone(stashbox)
+
+
+class TestEndpointMatching(unittest.TestCase):
+    """Test endpoint URL matching."""
+
+    def test_find_stash_id_for_endpoint(self):
+        """Test finding the correct stash_id for a given endpoint."""
+        entity = {
+            "id": "123",
+            "name": "Test Performer",
+            "stash_ids": [
+                {"endpoint": "https://stashdb.org/graphql", "stash_id": "stashdb-id-123"},
+                {"endpoint": "https://fansdb.cc/graphql", "stash_id": "fansdb-id-456"},
+            ]
+        }
+        target_endpoint = "https://stashdb.org/graphql"
+
+        stash_id = None
+        for sid in entity.get("stash_ids", []):
+            if sid.get("endpoint") == target_endpoint:
+                stash_id = sid.get("stash_id")
+                break
+
+        self.assertEqual(stash_id, "stashdb-id-123")
+
+    def test_no_stash_id_for_endpoint(self):
+        """Test when entity has no stash_id for the target endpoint."""
+        entity = {
+            "id": "123",
+            "name": "Test Performer",
+            "stash_ids": [
+                {"endpoint": "https://fansdb.cc/graphql", "stash_id": "fansdb-id-456"},
+            ]
+        }
+        target_endpoint = "https://stashdb.org/graphql"
+
+        stash_id = None
+        for sid in entity.get("stash_ids", []):
+            if sid.get("endpoint") == target_endpoint:
+                stash_id = sid.get("stash_id")
+                break
+
+        self.assertIsNone(stash_id)
+
+
+def run_all_tests():
+    """Run all tests."""
+    print("=" * 60)
+    print("Missing Scenes Plugin - Unit Tests")
+    print("=" * 60)
+
+    # Create test suite
+    loader = unittest.TestLoader()
+    suite = unittest.TestSuite()
+
+    # Add all test classes
+    suite.addTests(loader.loadTestsFromTestCase(TestFormatScene))
+    suite.addTests(loader.loadTestsFromTestCase(TestWhisparrPayload))
+    suite.addTests(loader.loadTestsFromTestCase(TestStashIdMatching))
+    suite.addTests(loader.loadTestsFromTestCase(TestErrorHandling))
+    suite.addTests(loader.loadTestsFromTestCase(TestSceneSorting))
+    suite.addTests(loader.loadTestsFromTestCase(TestGraphQLQueryConstruction))
+    suite.addTests(loader.loadTestsFromTestCase(TestEndpointSelection))
+    suite.addTests(loader.loadTestsFromTestCase(TestEndpointMatching))
+
+    # Run tests
+    runner = unittest.TextTestRunner(verbosity=2)
+    result = runner.run(suite)
+
+    print("\n" + "=" * 60)
+    print(f"Results: {result.testsRun} tests, "
+          f"{len(result.failures)} failures, "
+          f"{len(result.errors)} errors")
+    print("=" * 60)
+
+    return len(result.failures) == 0 and len(result.errors) == 0
+
+
+if __name__ == "__main__":
+    success = run_all_tests()
+    sys.exit(0 if success else 1)


### PR DESCRIPTION
## Summary

New plugin to discover scenes from StashDB that you don't have locally.

### Features
- Find missing scenes for performers and studios linked to stash-box
- Visual grid display with thumbnails, titles, dates, and performer info
- Direct links to view scenes on StashDB
- Multi-endpoint support (StashDB, FansDB, or any configured stash-box)
- Optional Whisparr integration for automated downloading
- Configurable stash-box endpoint selection in plugin settings

### Technical Details
- UI plugin (JavaScript + CSS) injected on performer/studio detail pages
- Python backend using `runPluginOperation` GraphQL mutation
- Paginated queries from stash-box (up to 1000 scenes per entity)
- No external dependencies (uses Python standard library only)
- 24 unit tests included

### Screenshots
The plugin adds a "Missing Scenes" button to performer and studio pages. Clicking it opens a modal showing all scenes from StashDB that aren't in your local library.

## Test Plan
- [x] Tested on performer pages - shows missing scenes correctly
- [x] Tested on studio pages - shows missing scenes correctly
- [x] Tested multi-endpoint selection (StashDB configured)
- [x] Unit tests pass (24 tests)
- [ ] Whisparr integration (not tested - user doesn't have Whisparr)

🤖 Generated with [Claude Code](https://claude.com/claude-code)