### PR TITLE
feat: Add file logging to mcMetadata and update missingScenes Whisparr API

### DIFF
--- a/plugins/mcMetadata/mcMetadata.py
+++ b/plugins/mcMetadata/mcMetadata.py
@@ -4,13 +4,14 @@ mcMetadata - Stash Plugin for Media Center Metadata Generation
 Generates NFO files for Jellyfin/Emby, organizes video files according to
 configurable templates, and exports performer images to media server folders.
 
-Version: 1.2.2
+Version: 1.2.3
 """
 
 import json
 import sys
-import stashapi.log as log
 from stashapi.stashapp import StashInterface
+from utils.logger import init_file_logger, close_file_logger
+import utils.logger as log
 from performer import process_all_performers
 from scene import process_all_scenes, process_scene
 
@@ -45,6 +46,7 @@ def get_settings(stash_instance):
     # with sensible defaults
     return {
         "dry_run": plugin_config.get("dryRun", True),  # Default to safe mode
+        "log_file_path": plugin_config.get("logFilePath", ""),  # Optional file logging
         "enable_hook": plugin_config.get("enableHook", False),  # Default off for safety
         "require_stash_id": plugin_config.get("requireStashId", False),  # Default off - process all scenes
         "enable_renamer": plugin_config.get("enableRenamer", False),
@@ -90,6 +92,11 @@ def main():
     """Main entry point for the plugin."""
     try:
         mode = get_plugin_mode()
+
+        # Initialize file logging if configured
+        if SETTINGS.get("log_file_path"):
+            init_file_logger(SETTINGS["log_file_path"])
+
         log.debug(f"Plugin mode: {mode}")
         log.debug(f"Dry run: {SETTINGS['dry_run']}")
 
@@ -145,6 +152,9 @@ def main():
     except Exception as err:
         log.error(f"Plugin error: {err}")
         sys.exit(1)
+    finally:
+        # Always close file logger to ensure log is written
+        close_file_logger()
 
 
 if __name__ == "__main__":

--- a/plugins/mcMetadata/mcMetadata.yml
+++ b/plugins/mcMetadata/mcMetadata.yml
@@ -1,7 +1,7 @@
 name: mcMetadata
 description: Generates NFO metadata files for Jellyfin/Emby, organizes/renames video files using customizable templates, and exports performer images to media server folders.
 url: https://github.com/carrotwaxr/stash-plugins/tree/main/plugins/mcMetadata
-version: 1.2.2
+version: 1.2.3
 exec:
   - python
   - "{pluginDir}/mcMetadata.py"
@@ -13,6 +13,10 @@ settings:
     displayName: Dry Run Mode
     description: Preview changes without making them. Check logs to see what would happen. Default is ON.
     type: BOOLEAN
+  logFilePath:
+    displayName: Log File Path
+    description: Path to write detailed log file during dry run. Leave empty to disable file logging. Example /data/mcMetadata.log
+    type: STRING
   enableHook:
     displayName: Enable Scene Update Hook
     description: Process scenes automatically when you update them. Disable to only use bulk tasks. Default is OFF.

--- a/plugins/mcMetadata/performer.py
+++ b/plugins/mcMetadata/performer.py
@@ -1,5 +1,5 @@
 import os
-import stashapi.log as log
+import utils.logger as log
 from utils.files import download_image
 
 # Constants

--- a/plugins/mcMetadata/scene.py
+++ b/plugins/mcMetadata/scene.py
@@ -1,5 +1,5 @@
 import os
-import stashapi.log as log
+import utils.logger as log
 from performer import process_performer
 from utils.files import download_image, rename_file, replace_file_ext
 from utils.nfo import build_nfo_xml

--- a/plugins/mcMetadata/utils/files.py
+++ b/plugins/mcMetadata/utils/files.py
@@ -1,6 +1,6 @@
 import os
 import urllib.request
-import stashapi.log as log
+import utils.logger as log
 
 
 def download_image(url, dest_filepath, settings):  # pragma: no cover

--- a/plugins/mcMetadata/utils/logger.py
+++ b/plugins/mcMetadata/utils/logger.py
@@ -1,0 +1,104 @@
+"""
+Custom logger that wraps stashapi.log and adds file logging support.
+
+When a log file path is configured, all log messages are written to both
+Stash's log system and to the specified file. This is especially useful
+for dry run mode where users want to review the full output before
+committing changes.
+"""
+
+import os
+from datetime import datetime
+import stashapi.log as stash_log
+
+# Global file handle for log file
+_log_file = None
+_log_file_path = None
+
+
+def init_file_logger(filepath):
+    """Initialize file logging if a path is provided.
+
+    Args:
+        filepath: Path to the log file. If empty/None, file logging is disabled.
+    """
+    global _log_file, _log_file_path
+
+    if not filepath:
+        return
+
+    try:
+        # Create directory if it doesn't exist
+        log_dir = os.path.dirname(filepath)
+        if log_dir and not os.path.exists(log_dir):
+            os.makedirs(log_dir)
+
+        # Open file in write mode (overwrites previous log)
+        _log_file = open(filepath, 'w', encoding='utf-8')
+        _log_file_path = filepath
+
+        # Write header
+        _log_file.write(f"mcMetadata Log - {datetime.now().isoformat()}\n")
+        _log_file.write("=" * 80 + "\n\n")
+        _log_file.flush()
+
+        stash_log.info(f"File logging enabled: {filepath}")
+    except Exception as err:
+        stash_log.error(f"Failed to initialize file logging: {err}")
+
+
+def close_file_logger():
+    """Close the log file if open."""
+    global _log_file, _log_file_path
+
+    if _log_file:
+        try:
+            _log_file.write("\n" + "=" * 80 + "\n")
+            _log_file.write(f"Log completed at {datetime.now().isoformat()}\n")
+            _log_file.close()
+            stash_log.info(f"Log file written to: {_log_file_path}")
+        except Exception:
+            pass
+        finally:
+            _log_file = None
+            _log_file_path = None
+
+
+def _write_to_file(level, message):
+    """Write a message to the log file if open."""
+    if _log_file:
+        try:
+            timestamp = datetime.now().strftime("%H:%M:%S")
+            _log_file.write(f"[{timestamp}] [{level}] {message}\n")
+            _log_file.flush()
+        except Exception:
+            pass
+
+
+def debug(message):
+    """Log a debug message."""
+    stash_log.debug(message)
+    _write_to_file("DEBUG", message)
+
+
+def info(message):
+    """Log an info message."""
+    stash_log.info(message)
+    _write_to_file("INFO", message)
+
+
+def warning(message):
+    """Log a warning message."""
+    stash_log.warning(message)
+    _write_to_file("WARN", message)
+
+
+def error(message):
+    """Log an error message."""
+    stash_log.error(message)
+    _write_to_file("ERROR", message)
+
+
+def progress(value):
+    """Update progress bar."""
+    stash_log.progress(value)

--- a/plugins/mcMetadata/utils/replacer.py
+++ b/plugins/mcMetadata/utils/replacer.py
@@ -1,6 +1,6 @@
 import os
 import re
-import stashapi.log as log
+import utils.logger as log
 
 
 def __replacer_female_performers(scene):

--- a/plugins/mcMetadata/utils/settings.py
+++ b/plugins/mcMetadata/utils/settings.py
@@ -4,7 +4,7 @@ import configparser
 import os
 import re
 import sys
-import stashapi.log as log
+import utils.logger as log
 
 # Required settings for all modes
 REQUIRED_SETTINGS = ["dry_run", "enable_actor_images", "enable_hook", "enable_renamer"]


### PR DESCRIPTION
## Summary

- **mcMetadata**: Add file logging capability for reviewing dry run output before committing changes
- **missingScenes**: Update Whisparr API integration to match Stasharr's approach (movie-mode compatible)

## Changes

### mcMetadata v1.2.3
- New `logFilePath` setting to write detailed logs to a file
- New `utils/logger.py` module wrapping stashapi.log with file output
- All modules updated to use new logger

### missingScenes (Whisparr API Update)
- Rewrote Whisparr API functions to use movie-mode endpoints (compatible with Stasharr)
- `whisparr_get_scene_by_stash_id()` - check if scene exists via `movie?stashId=`
- `whisparr_lookup_scene()` - lookup scene in TPDB via `lookup/scene?term=stash:`
- `whisparr_add_scene()` - add scene via `POST movie`
- `whisparr_trigger_search()` - trigger search for a specific scene
- `whisparr_get_all_scenes()` - paginated scene fetching
- Simplified `add_to_whisparr()` to follow Stasharr's workflow

## Test plan
- [ ] Test mcMetadata dry run with file logging enabled
- [ ] Test missingScenes with Whisparr in movie-mode configuration
- [ ] Verify Stasharr compatibility with shared Whisparr instance

🤖 Generated with [Claude Code](https://claude.com/claude-code)