### PR TITLE
fix(performerImageSearch): rename Bing to DuckDuckGo in settings

### DIFF
--- a/plugins/performerImageSearch/image_search.py
+++ b/plugins/performerImageSearch/image_search.py
@@ -916,6 +916,11 @@ def search_duckduckgo_images(query, size="Large", layout="All", max_results=50):
             width = img.get("width", 0)
             height = img.get("height", 0)
 
+            # Skip small images (< 300px on shorter dimension)
+            if width > 0 and height > 0:
+                if min(width, height) < 300:
+                    continue
+
             results.append({
                 "thumbnail": thumb_url or img_url,
                 "image": img_url,

--- a/plugins/performerImageSearch/performer-image-search.js
+++ b/plugins/performerImageSearch/performer-image-search.js
@@ -14,7 +14,7 @@
     enableEliteBabes: true,
     enableBoobpedia: true,
     enableJavDatabase: true,
-    enableBing: true,
+    enableDuckDuckGo: true,
   };
 
   // All available sources (will be filtered by settings)
@@ -25,7 +25,7 @@
     { id: "elitebabes", settingKey: "enableEliteBabes" },
     { id: "boobpedia", settingKey: "enableBoobpedia" },
     { id: "javdatabase", settingKey: "enableJavDatabase" },
-    { id: "bing", settingKey: "enableBing" },
+    { id: "duckduckgo", settingKey: "enableDuckDuckGo" },
   ];
 
   // Aspect ratio thresholds

--- a/plugins/performerImageSearch/performerImageSearch.yml
+++ b/plugins/performerImageSearch/performerImageSearch.yml
@@ -47,9 +47,9 @@ settings:
     displayName: Enable JavDatabase
     description: Japanese adult video performers. Enabled by default.
     type: BOOLEAN
-  enableBing:
-    displayName: Enable Bing Images
-    description: Fallback search. Works for all performer types. Enabled by default.
+  enableDuckDuckGo:
+    displayName: Enable DuckDuckGo Images
+    description: Fallback search with SafeSearch off. Works for all performer types. Enabled by default.
     type: BOOLEAN
 
 # Python backend for image search (called via runPluginOperation from JS)


### PR DESCRIPTION
## Summary

- Rename `enableBing` to `enableDuckDuckGo` in YAML settings and JavaScript
- Filter out small images (< 300px on shorter dimension) from DuckDuckGo results

## Background

Follow-up to #23 - the settings UI still showed "Enable Bing Images" after replacing Bing with DuckDuckGo. Also, small images like 150x250 were still being returned because we weren't filtering based on the dimensions returned by the DuckDuckGo API.

## Test plan

- [x] All 9 tests pass
- [x] DuckDuckGo results now only include images >= 300px on shorter dimension
- [x] Settings YAML shows "Enable DuckDuckGo Images"