### PR TITLE
fix: add title matching and fix React input update in Scene Matcher

### DIFF
--- a/plugins/sceneMatcher/scene-matcher.css
+++ b/plugins/sceneMatcher/scene-matcher.css
@@ -130,6 +130,10 @@
   background: #198754;
 }
 
+.sm-attr-tag.sm-attr-title {
+  background: #fd7e14;
+}
+
 /* Modal Body - Results Grid */
 .sm-modal-body {
   flex: 1;


### PR DESCRIPTION
- Add LCS-based title similarity scoring (+10 for exact, +5 for partial)
- Fix React controlled input value update using native setter
- Display title match indicator in results badge
- Update tests for new 3-tuple score_scene return value