### PR TITLE
fix: handle 0.0.0.0 binding in plugin connection

### DIFF
--- a/plugins/missingScenes/missing_scenes.py
+++ b/plugins/missingScenes/missing_scenes.py
@@ -82,9 +82,16 @@ def get_stash_connection():
         if _input_data is None:
             _input_data = json.loads(sys.stdin.read())
         server_connection = _input_data.get("server_connection", {})
+
+        # Handle 0.0.0.0 binding - can't connect TO 0.0.0.0, use localhost instead
+        # See: https://github.com/stashapp/stash/issues/5103
+        host = server_connection.get("Host", "localhost")
+        if host == "0.0.0.0":
+            host = "localhost"
+
         _stash_connection = {
             "url": server_connection.get("Scheme", "http") + "://" +
-                   server_connection.get("Host", "localhost") + ":" +
+                   host + ":" +
                    str(server_connection.get("Port", 9999)) + "/graphql",
             "api_key": server_connection.get("SessionCookie", {}).get("Value"),
         }


### PR DESCRIPTION
## Summary
- Fix Missing Scenes plugin failing when Stash is bound to `0.0.0.0`
- Replace `0.0.0.0` with `localhost` when building the connection URL

## Problem
When Stash is configured to listen on `0.0.0.0` (accept connections from any interface), it passes that address to plugins via `server_connection.Host`. However, `0.0.0.0` is not a valid destination address - you can only *listen* on it, not *connect* to it.

On Windows this causes `WinError 10049: The requested address is not valid in its context`.

## Solution
Check if the host is `0.0.0.0` and replace with `localhost` before building the GraphQL endpoint URL. This is the same approach recommended in stashapp/stash#5103 and used by the `stashapp-tools` library.

## Test plan
- [ ] Test plugin with Stash bound to `0.0.0.0`
- [ ] Test plugin with Stash bound to `127.0.0.1` (should still work)