### PR TITLE
fix: prevent date display off-by-one error due to timezone

### DIFF
--- a/plugins/missingScenes/missing-scenes.js
+++ b/plugins/missingScenes/missing-scenes.js
@@ -130,7 +130,11 @@
   function formatDate(dateStr) {
     if (!dateStr) return "";
     try {
-      const date = new Date(dateStr);
+      // Parse as local date components to avoid timezone shift
+      // new Date("2025-12-07") is interpreted as UTC midnight, which displays
+      // as the previous day for users west of UTC
+      const [year, month, day] = dateStr.split("-").map(Number);
+      const date = new Date(year, month - 1, day);
       return date.toLocaleDateString(undefined, {
         year: "numeric",
         month: "short",

--- a/plugins/sceneMatcher/scene-matcher.js
+++ b/plugins/sceneMatcher/scene-matcher.js
@@ -166,7 +166,11 @@
   function formatDate(dateStr) {
     if (!dateStr) return "";
     try {
-      const date = new Date(dateStr);
+      // Parse as local date components to avoid timezone shift
+      // new Date("2025-12-07") is interpreted as UTC midnight, which displays
+      // as the previous day for users west of UTC
+      const [year, month, day] = dateStr.split("-").map(Number);
+      const date = new Date(year, month - 1, day);
       return date.toLocaleDateString(undefined, {
         year: "numeric",
         month: "short",


### PR DESCRIPTION
## Summary

- Fixed date formatting bug where dates displayed one day earlier than StashDB for users west of UTC
- Applied fix to both `missingScenes` and `sceneMatcher` plugins

## Root Cause

`new Date("2025-12-07")` is interpreted as UTC midnight. When `toLocaleDateString()` converts to local time, users in timezones west of UTC (Americas, Pacific) see the previous day.

## Solution

Parse date strings as local date components instead of letting JavaScript interpret them as UTC:

```javascript
const [year, month, day] = dateStr.split("-").map(Number);
const date = new Date(year, month - 1, day);
```

## Test plan

- [ ] Verify dates in Missing Scenes panel match StashDB exactly
- [ ] Verify dates in Scene Matcher panel match StashDB exactly
- [ ] Test with user in timezone west of UTC (e.g., PST/PDT)

Fixes: https://discourse.stashapp.cc/t/missing-scenes/4620/8