### PR TITLE
fix(tagManager): improve tag matching UX

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ Match and sync local tags with StashDB tags. Bulk cleanup your tag library with 
 - Field-by-field merge dialog (name, description, aliases)
 - Manual search for edge cases
 - Links tags to StashDB via `stash_ids`
+- Tag Hierarchy view for browsing parent/child relationships
 
 [Documentation](plugins/tagManager/README.md)
 

--- a/plugins/tagManager/README.md
+++ b/plugins/tagManager/README.md
@@ -12,6 +12,7 @@ Match and sync local tags with stash-box tags. Bulk cleanup your tag library wit
 - **Field-by-field merge** - Choose what to keep vs. what to update
 - **Manual search** - Search the stash-box directly for edge cases
 - **Stash-box linking** - Adds `stash_ids` to tags for future syncing
+- **Tag Hierarchy View** - Browse your tags in a visual tree structure showing parent/child relationships
 
 ## Requirements
 
@@ -28,7 +29,7 @@ Match and sync local tags with stash-box tags. Bulk cleanup your tag library wit
 
 ## Usage
 
-1. Navigate to `/plugin/tag-manager` in your Stash UI
+1. Navigate to the Tags page and click the tag icon button, or go to `/plugins/tag-manager` in your Stash UI
 2. Select your stash-box endpoint from the dropdown
 3. The plugin will load cached tags (or fetch them if no cache exists)
 4. Click **Find Matches for Page** to search all visible tags
@@ -37,8 +38,16 @@ Match and sync local tags with stash-box tags. Bulk cleanup your tag library wit
    - **More** - View all potential matches and search manually
 6. In the diff dialog, choose what to update for each field:
    - **Keep** - Keep your current value
-   - **StashDB** - Use the stash-box value
-   - **Merge** (aliases only) - Combine both sets
+   - **Keep + Add stash-box alias** - Keep your name but add the stash-box name as an alias
+   - **StashDB** - Use the stash-box value (your old name is auto-added as an alias)
+
+### Tag Hierarchy
+
+1. Navigate to the Tags page and click the sitemap icon button, or go to `/plugins/tag-hierarchy`
+2. Browse your tags in a tree view showing parent/child relationships
+3. Click arrows to expand/collapse branches
+4. Use "Expand All" / "Collapse All" buttons for quick navigation
+5. Toggle "Show images" to show/hide tag thumbnails
 
 ## Tag Caching
 


### PR DESCRIPTION
## Summary
- Rename "Keep + Add as Alias" to "Keep + Add stash-box alias" for clarity
- Auto-add local name as alias when selecting StashDB name option (preserves old name when renaming)
- Fix Search button on no-match tags to open manual search modal instead of re-running failed search
- Fix page titles with retry approach to overcome Stash's title management

## Test plan
- [ ] Open Tag Matcher page and verify title shows "Tag Matcher | Stash"
- [ ] Open Tag Hierarchy page and verify title shows "Tag Hierarchy | Stash"
- [ ] Find a tag with no matches, click Search, verify manual search modal opens
- [ ] In diff dialog, verify radio label says "Keep + Add stash-box alias"
- [ ] In diff dialog, select "StashDB" for name, verify local name is auto-added to aliases