### PR TITLE
fix(missingScenes): improve filter state display and count accuracy

### DIFF
--- a/plugins/missingScenes/missing-scenes.js
+++ b/plugins/missingScenes/missing-scenes.js
@@ -467,6 +467,9 @@
         entityLabel = "Entity";
     }
 
+    // Check if filters are active
+    const filtersActive = data.filters_active || false;
+
     // Handle both legacy (missing_count) and paginated (missing_count_estimate/loaded) responses
     let missingDisplay;
     if (data.is_complete !== undefined) {
@@ -478,11 +481,19 @@
       } else if (estimate !== null) {
         missingDisplay = `~${estimate} (${loaded} loaded)`;
       } else {
+        // When filters are active or no estimate, just show loaded count
         missingDisplay = `${loaded} loaded`;
       }
     } else {
       // Legacy response
       missingDisplay = `${data.missing_count || 0}`;
+    }
+
+    // Build stats HTML - when filters are active, indicate filtered results
+    let stashdbLabel = `On ${data.stashdb_name || "StashDB"}:`;
+    let stashdbValue = `${data.total_on_stashdb || 0}`;
+    if (filtersActive) {
+      stashdbLabel = `Total on ${data.stashdb_name || "StashDB"}:`;
     }
 
     statsEl.innerHTML = `
@@ -491,15 +502,15 @@
         <span class="ms-stat-value">${data.entity_name || "Unknown"}</span>
       </div>
       <div class="ms-stat">
-        <span class="ms-stat-label">On ${data.stashdb_name || "StashDB"}:</span>
-        <span class="ms-stat-value">${data.total_on_stashdb || 0}</span>
+        <span class="ms-stat-label">${stashdbLabel}</span>
+        <span class="ms-stat-value">${stashdbValue}</span>
       </div>
       <div class="ms-stat">
         <span class="ms-stat-label">You Have:</span>
         <span class="ms-stat-value">${data.total_local || 0}</span>
       </div>
       <div class="ms-stat ms-stat-highlight">
-        <span class="ms-stat-label">Missing:</span>
+        <span class="ms-stat-label">Missing${filtersActive ? " (filtered)" : ""}:</span>
         <span class="ms-stat-value">${missingDisplay}</span>
       </div>
     `;

--- a/plugins/missingScenes/missing_scenes.py
+++ b/plugins/missingScenes/missing_scenes.py
@@ -1528,6 +1528,22 @@ def find_missing_scenes_paginated(entity_type, entity_id, plugin_settings,
     total_on_stashdb = result["total_on_stashdb"]
     is_complete = result["is_complete"]
 
+    # Determine which filters are active (for frontend display)
+    active_filters = []
+    if filter_favorite_performers:
+        active_filters.append("performers")
+    if filter_favorite_studios:
+        active_filters.append("studios")
+    if filter_favorite_tags:
+        active_filters.append("tags")
+
+    # When filters are active, the estimate is not meaningful
+    # (we'd have to scan all pages to know the filtered count)
+    filters_active = len(active_filters) > 0
+    missing_count_estimate = None
+    if not filters_active and not is_complete:
+        missing_count_estimate = total_on_stashdb - total_local
+
     return {
         "entity_name": entity.get("name"),
         "entity_type": entity_type,
@@ -1535,13 +1551,15 @@ def find_missing_scenes_paginated(entity_type, entity_id, plugin_settings,
         "stashdb_url": stashdb_url.replace("/graphql", ""),
         "total_on_stashdb": total_on_stashdb,
         "total_local": total_local,
-        "missing_count_estimate": total_on_stashdb - total_local if not is_complete else None,
+        "missing_count_estimate": missing_count_estimate,
         "missing_count_loaded": len(formatted_scenes),
         "cursor": result["next_cursor"],
         "has_more": result["next_cursor"] is not None,
         "is_complete": is_complete,
         "missing_scenes": formatted_scenes,
-        "whisparr_configured": whisparr_configured
+        "whisparr_configured": whisparr_configured,
+        "filters_active": filters_active,
+        "active_filters": active_filters
     }
 
 


### PR DESCRIPTION
## Summary

Fixes UI issues with the favorite entity filters feature:

1. **Filtered count indicator** - When filters are enabled, the "Missing" stat now shows "(filtered)" to indicate the count is a filtered subset
2. **Accurate estimate** - Don't show misleading "~X estimated" when filters are active since that estimate is based on unfiltered counts
3. **Clarified labels** - When filtering, shows "Total on StashDB" instead of "On StashDB" to clarify the number is the unfiltered total

## Changes

**Backend (`missing_scenes.py`):**
- Added `filters_active` boolean and `active_filters` list to response
- `missing_count_estimate` is now `null` when filters are enabled (can't know filtered count without scanning all pages)

**Frontend (`missing-scenes.js`):**
- Shows "(filtered)" suffix on Missing label when filters are active
- Shows "Total on StashDB" instead of "On StashDB" when filtering

## Re: 504 on Tags

The 504 timeout when filtering by studios on a Tag page is a StashDB server-side timeout - some tags have thousands of scenes and the query times out. This is not something we can fix in the plugin code. The same queries work fine on Performer and Studio pages with smaller result sets.

## Test Plan

- [x] Unit tests pass (75 tests)
- [x] Integration tests pass (5 tests)
- [ ] Manual: Open Missing Scenes on Performer, enable "Favorite Studios" → verify "(filtered)" appears
- [ ] Manual: Enable a filter then disable → verify estimate returns to normal display