### PR TITLE
fix(missingScenes): use correct /plugins/ route path prefix

### DIFF
--- a/plugins/missingScenes/missing-scenes-browse.js
+++ b/plugins/missingScenes/missing-scenes-browse.js
@@ -2,7 +2,7 @@
   "use strict";
 
   const PLUGIN_ID = "missingScenes";
-  const BROWSE_PATH = "/plugin/missingScenes/browse";
+  const BROWSE_PATH = "/plugins/missing-scenes";
 
   /**
    * Get the GraphQL endpoint URL


### PR DESCRIPTION
## Summary

The route was using `/plugin/missingScenes/browse` (singular 'plugin') but Stash requires `/plugins/` (plural) for plugin routes to work.

Changed to `/plugins/missing-scenes` to match the working TagManager pattern (`/plugins/tag-manager`).

## Test plan

- [x] Unit tests passing (83 tests)
- [ ] Navigate to `/plugins/missing-scenes` - should show Missing Scenes browse page
- [ ] "Missing Scenes" button on Scenes page should navigate correctly