### PR TITLE
fix(missingScenes): add tags field to SCENE_FIELDS for tag filtering

### DIFF
--- a/plugins/missingScenes/stashbox_api.py
+++ b/plugins/missingScenes/stashbox_api.py
@@ -332,6 +332,10 @@ SCENE_FIELDS = """
         }
         as
     }
+    tags {
+        id
+        name
+    }
 """
 
 


### PR DESCRIPTION
## Summary

Fixes tag filtering on the Missing Scenes browse page.

## Root Cause

The `SCENE_FIELDS` GraphQL fragment in `stashbox_api.py` didn't include the `tags` field. When scenes were fetched from StashDB, they had no tag data. The filter then compared against an empty set and always failed:

```python
scene_tag_ids = {t.get("id") for t in scene.get("tags", [])}  # Always empty!
if not scene_tag_ids & favorite_tag_ids:  # Always fails
    return False
```

## Fix

Add `tags { id name }` to `SCENE_FIELDS` so scenes include tag data for filtering.

## Test plan

- [x] Unit tests pass (83 tests)
- [ ] Enable "Favorite Tags" filter on browse page - should now filter correctly
- [ ] Performer and studio filters still work