### PR TITLE
fix(missingScenes): apply favorite filters client-side in browse_stashdb

### DIFF
--- a/plugins/missingScenes/missing_scenes.py
+++ b/plugins/missingScenes/missing_scenes.py
@@ -1876,14 +1876,16 @@ def browse_stashdb(plugin_settings, page_size=50, cursor=None, sort="DATE", dire
             is_complete = True
             break
 
-        # Filter out owned scenes
+        # Filter out owned scenes and apply favorite filters
         for i, scene in enumerate(scenes):
             if i < current_offset:
                 continue
 
             scene_id = scene.get("id")
             if scene_id and scene_id not in local_ids:
-                collected.append(scene)
+                # Apply favorite filters client-side (StashDB query only handles excludes)
+                if scene_passes_favorite_filters(scene, performer_ids, studio_ids, tag_ids):
+                    collected.append(scene)
 
             if len(collected) >= page_size:
                 # Save position for next request


### PR DESCRIPTION
## Summary

Fixes the Favorite Tags filter on the Missing Scenes browse page - it was returning all scenes even when the filter was enabled.

## Root Cause

When `excludedTags` is configured in plugin settings, the `query_scenes_browse()` function applies EXCLUDES to tags in the StashDB query. Since StashDB doesn't support multiple tag modifiers in the same query, the favorite tags INCLUDES filter was being ignored:

```python
if excluded_tag_ids:
    filter_input["tags"] = {"value": ..., "modifier": "EXCLUDES"}
elif tag_ids:  # <-- Never runs when excluded_tags exist!
    filter_input["tags"] = {"value": ..., "modifier": "INCLUDES"}
```

## Fix

Apply favorite filters (performers, studios, tags) client-side in `browse_stashdb()` using the existing `scene_passes_favorite_filters()` function. This matches how `fetch_until_full()` already handles this case for entity-specific queries.

## Test plan

- [x] Unit tests pass (91 tests)
- [ ] Enable "Favorite Tags" filter on browse page with excludedTags configured - should now filter correctly
- [ ] Performer and studio filters should continue to work