### PR TITLE
fix(mcMetadata): cross-device link error and stashapp-tools version check

### DIFF
--- a/plugins/mcMetadata/utils/files.py
+++ b/plugins/mcMetadata/utils/files.py
@@ -1,4 +1,5 @@
 import os
+import shutil
 import tempfile
 import urllib.request
 import urllib.error
@@ -102,8 +103,8 @@ def download_image(url, dest_filepath, settings):
         if dest_dir and not os.path.exists(dest_dir):
             os.makedirs(dest_dir)
 
-        # Move temp file to destination
-        os.replace(temp_path, dest_filepath)
+        # Move temp file to destination (shutil.move handles cross-filesystem moves)
+        shutil.move(temp_path, dest_filepath)
         log.debug(f"Saved image to {dest_filepath}")
         return True
 
@@ -135,7 +136,7 @@ def rename_file(filepath, dest_filepath, settings):
             os.makedirs(dir)  # pragma: no cover
         try:
             if settings["dry_run"] is False:
-                os.rename(filepath, dest_filepath)  # pragma: no cover
+                shutil.move(filepath, dest_filepath)  # pragma: no cover
                 log.debug(f"Renamed {filepath} to {dest_filepath}")  # pragma: no cover
             return dest_filepath
         except Exception as err:  # pragma: no cover


### PR DESCRIPTION
## Summary

- Fix cross-device link error when downloading images in Docker environments
- Add runtime version check for stashapp-tools compatibility

## Changes

**Cross-device link fix (`files.py`):**
- Replace `os.replace()` and `os.rename()` with `shutil.move()` to handle cross-filesystem moves
- In Docker, `/tmp` and `/data` are often on different mount points, causing `[Errno 18] Cross-device link` errors

**Version check (`mcMetadata.py`):**
- Add `check_stashapp_tools_version()` that warns users if they have stashapp-tools < 0.2.59
- Older versions have a recursive GraphQL fragment bug causing "Cannot spread fragment 'Folder' within itself" errors on Stash schema 72+

## Test plan

- [x] Unit tests pass (31/31)
- [x] Code review completed
- [ ] Manual test in Docker environment with cross-filesystem mounts