### PR TITLE
fix(mcMetadata): prevent duplicate log entries from cascading hook invocations

### DIFF
--- a/plugins/mcMetadata/mcMetadata.py
+++ b/plugins/mcMetadata/mcMetadata.py
@@ -184,6 +184,12 @@ def main():
                 log.debug(f"Scene {scene_id} has no StashID, skipping (requireStashId is enabled)")
                 return
 
+            # Early exit if scene is already organized (prevents cascading hook invocations)
+            # When renamer marks scenes as organized, this acts as a "already processed" flag
+            if SETTINGS.get("renamer_enable_mark_organized", False) and scene.get("organized", False):
+                log.debug(f"Scene {scene_id} already organized, skipping to prevent hook cascade")
+                return
+
             log.info(f"Processing scene {scene_id}")
             process_scene(scene, stash, SETTINGS, api_key)
 

--- a/plugins/mcMetadata/scene.py
+++ b/plugins/mcMetadata/scene.py
@@ -170,6 +170,7 @@ def __rename_videos(scene, stash, settings):
     primary_path = None
     original_primary_path = files_to_process[0]["path"]  # Store before loop
     used_paths = set()  # Track paths we've used to detect conflicts
+    files_moved = False  # Track if any files were actually moved
 
     for idx, file_info in enumerate(files_to_process):
         video_path = file_info["path"]
@@ -250,6 +251,7 @@ def __rename_videos(scene, stash, settings):
                 continue
 
             log.info(f"Moved file {idx + 1} to: {expected_path}")
+            files_moved = True
             if idx == 0:
                 primary_path = expected_path
 
@@ -259,8 +261,8 @@ def __rename_videos(scene, stash, settings):
                 primary_path = video_path
             continue
 
-    # Mark as organized if enabled (only once per scene)
-    if settings.get("renamer_enable_mark_organized", False) and not settings["dry_run"]:
+    # Mark as organized if enabled and files were actually moved
+    if files_moved and settings.get("renamer_enable_mark_organized", False) and not settings["dry_run"]:
         try:
             stash.update_scene({"id": scene["id"], "organized": True})
             log.debug(f"Marked Scene {scene['id']} as organized")


### PR DESCRIPTION
## Summary

- Fixes cascading `Scene.Update.Post` hook invocations that caused 10+ duplicate log entries per scene
- Adds early exit guard when scene is already organized
- Only marks scene as organized if files were actually moved

## Root Cause

The `Scene.Update.Post` hook was cascading because:
1. `moveFiles` GraphQL mutation triggered another hook
2. `stash.update_scene()` for marking organized triggered another hook
3. Each invocation processed the scene again, writing NFO and downloading images

## Test plan

- [x] Unit tests pass (31/31)
- [ ] Manual test: process a scene and verify only one set of log entries appears
- [ ] Verify scenes are still marked as organized after file moves


Generated with [Claude Code](https://claude.com/claude-code)