### PR TITLE
fix(tagManager): save context menu tag before hiding menu

### DIFF
--- a/plugins/tagManager/tag-manager.js
+++ b/plugins/tagManager/tag-manager.js
@@ -2962,20 +2962,25 @@
     const parentIdToRemove = e.target.dataset.parentId;
 
     if (!contextMenuTag) return;
+
+    // Save references before hideContextMenu() clears them
+    const tag = contextMenuTag;
+    const tagId = contextMenuTag.id;
+
     hideContextMenu();
 
     switch (action) {
       case 'add-parent':
-        showTagSearchDialog('parent', contextMenuTag);
+        showTagSearchDialog('parent', tag);
         break;
       case 'add-child':
-        showTagSearchDialog('child', contextMenuTag);
+        showTagSearchDialog('child', tag);
         break;
       case 'remove-parent':
-        await removeParent(contextMenuTag.id, parentIdToRemove);
+        await removeParent(tagId, parentIdToRemove);
         break;
       case 'make-root':
-        await makeRoot(contextMenuTag.id);
+        await makeRoot(tagId);
         break;
     }
   }


### PR DESCRIPTION
## Summary

Fix crash when clicking "Remove from parent" or "Make root" in the hierarchy context menu.

## Problem

`handleContextMenuAction` was calling `hideContextMenu()` which sets `contextMenuTag = null`, then trying to access `contextMenuTag.id` for the action - resulting in:

```
TypeError: Cannot read properties of null (reading 'id')
```

## Solution

Save the tag reference and ID to local variables before calling `hideContextMenu()`.

## Test plan
- [ ] Right-click a nested tag → "Remove from parent" should work
- [ ] Right-click a tag with parents → "Make root" should work

🤖 Generated with [Claude Code](https://claude.com/claude-code)