### PR TITLE
feat(tagManager): add Update Linked Tags to backfill metadata

### DIFF
--- a/plugins/tagManager/tagManager.yml
+++ b/plugins/tagManager/tagManager.yml
@@ -1,6 +1,6 @@
 name: Tag Manager
 description: Match and sync local tags with stash-box endpoints. Features multi-endpoint support, tag caching, layered search (exact, fuzzy, synonym), and field-by-field merge dialog.
-version: 0.3.0
+version: 0.4.0
 url: https://github.com/carrotwaxr/stash-plugins
 
 ui:


### PR DESCRIPTION
## Summary
- Adds an "Update Linked Tags" button to the Browse Stash-Box tab
- Finds linked tags with missing description or aliases and backfills them from stash-box data
- Merges aliases intelligently (case-insensitive dedup, appends new ones)
- Only touches tags that actually need updating — skips tags already up to date

Addresses the workflow gap where tags created through Stash's Scene Tagger get a `stash_id` but no description or aliases, then show as "Linked" in TagManager with no way to update them.

Closes #97