### PR TITLE
feat(tagManager): add settings for default name/description selection

### DIFF
--- a/plugins/tagManager/tag-manager.js
+++ b/plugins/tagManager/tag-manager.js
@@ -13,6 +13,8 @@
     enableSynonymSearch: true,
     fuzzyThreshold: 80,
     pageSize: 25,
+    preferStashBoxName: false,
+    preferStashBoxDescription: false,
   };
 
   // State
@@ -116,6 +118,8 @@
         enableSynonymSearch: pluginConfig.enableSynonymSearch !== false,
         fuzzyThreshold: parseInt(pluginConfig.fuzzyThreshold) || DEFAULTS.fuzzyThreshold,
         pageSize: parseInt(pluginConfig.pageSize) || DEFAULTS.pageSize,
+        preferStashBoxName: pluginConfig.preferStashBoxName === true,
+        preferStashBoxDescription: pluginConfig.preferStashBoxDescription === true,
       };
 
       // Load configured stash-boxes
@@ -2176,11 +2180,15 @@
     const match = matches[matchIndex];
     const stashdbTag = match.tag;
 
-    // Determine defaults: use StashDB value if local is empty
-    // For name: if local differs from StashDB, default to "keep + add alias"
+    // Determine defaults for name and description selections.
+    // Settings can override to always prefer stash-box values.
     const namesMatch = tag.name.toLowerCase() === stashdbTag.name.toLowerCase();
-    const nameDefault = !tag.name ? 'stashdb' : (namesMatch ? 'local' : 'local_add_alias');
-    const descDefault = tag.description ? 'local' : 'stashdb';
+    const nameDefault = settings.preferStashBoxName
+      ? 'stashdb'
+      : (!tag.name ? 'stashdb' : (namesMatch ? 'local' : 'local_add_alias'));
+    const descDefault = settings.preferStashBoxDescription
+      ? 'stashdb'
+      : (tag.description ? 'local' : 'stashdb');
 
     // Alias editing state - start with merged aliases
     let editableAliases = new Set([...(tag.aliases || []), ...(stashdbTag.aliases || [])]);

--- a/plugins/tagManager/tagManager.yml
+++ b/plugins/tagManager/tagManager.yml
@@ -30,6 +30,14 @@ settings:
     displayName: Scene Tag Sync - Dry Run
     description: Preview what tags would be added without making changes (caps at 200 scenes). Default is enabled for safety.
     type: BOOLEAN
+  preferStashBoxName:
+    displayName: Default to Stash-Box Name
+    description: In the merge dialog, default the Name selection to the stash-box value instead of keeping the local name.
+    type: BOOLEAN
+  preferStashBoxDescription:
+    displayName: Default to Stash-Box Description
+    description: In the merge dialog, default the Description selection to the stash-box value instead of keeping the local description.
+    type: BOOLEAN
   categoryMappings:
     displayName: Category Mappings (Internal)
     description: JSON mapping of StashDB categories to local parent tag IDs. Managed automatically.


### PR DESCRIPTION
## Summary
- Adds "Default to Stash-Box Name" and "Default to Stash-Box Description" settings in plugin configuration
- When enabled, the merge dialog defaults to the stash-box value instead of keeping the local value
- When disabled (default), preserves the existing smart behavior (use stash-box if local is empty, keep local otherwise)

Closes #82