### PR TITLE
Show matching tag pills on Missing Scenes grid

### DIFF
--- a/plugins/missingScenes/missing-scenes-browse.js
+++ b/plugins/missingScenes/missing-scenes-browse.js
@@ -38,6 +38,7 @@
   let filterFavoritePerformers = false;
   let filterFavoriteStudios = false;
   let filterFavoriteTags = false;
+  let activeFilterTagIds = [];
   let whisparrConfigured = false;
   let stashdbUrl = "";
 
@@ -174,6 +175,7 @@
           const card = createSceneCard(scene, {
             stashdbUrl: stashdbUrl || "https://stashdb.org",
             whisparrConfigured: whisparrConfigured,
+            activeFilterTagIds: activeFilterTagIds,
           });
           grid.appendChild(card);
         }
@@ -214,6 +216,7 @@
       hasMore = result.has_more;
       whisparrConfigured = result.whisparr_configured;
       stashdbUrl = result.stashdb_url || "https://stashdb.org";
+      activeFilterTagIds = result.active_filter_tag_ids || [];
 
       isLoading = false;
       renderPage(container, {

--- a/plugins/missingScenes/missing-scenes-core.js
+++ b/plugins/missingScenes/missing-scenes-core.js
@@ -257,9 +257,26 @@
       }
     }
 
+    // Matching tags (shown when tag filter is active)
+    const matchingTags = document.createElement("div");
+    matchingTags.className = "ms-scene-tags";
+    if (config.activeFilterTagIds && config.activeFilterTagIds.length > 0 && scene.tags) {
+      const filterSet = new Set(config.activeFilterTagIds);
+      const matched = scene.tags.filter((t) => filterSet.has(t.id));
+      for (const tag of matched) {
+        const pill = document.createElement("span");
+        pill.className = "ms-tag-pill";
+        pill.textContent = tag.name;
+        matchingTags.appendChild(pill);
+      }
+    }
+
     info.appendChild(title);
     info.appendChild(meta);
     info.appendChild(performers);
+    if (matchingTags.childElementCount > 0) {
+      info.appendChild(matchingTags);
+    }
 
     // Actions
     const actions = document.createElement("div");

--- a/plugins/missingScenes/missing-scenes.css
+++ b/plugins/missingScenes/missing-scenes.css
@@ -257,6 +257,24 @@
   text-overflow: ellipsis;
 }
 
+/* Scene Tags (matching filter pills) */
+.ms-scene-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+  margin-top: 2px;
+}
+
+.ms-tag-pill {
+  display: inline-block;
+  padding: 1px 6px;
+  font-size: 10px;
+  color: #ddd;
+  background: #3a3a5c;
+  border-radius: 3px;
+  white-space: nowrap;
+}
+
 /* Scene Actions */
 .ms-scene-actions {
   display: flex;

--- a/plugins/missingScenes/missing-scenes.js
+++ b/plugins/missingScenes/missing-scenes.js
@@ -39,6 +39,7 @@
   let filterFavoritePerformers = false;
   let filterFavoriteStudios = false;
   let filterFavoriteTags = false;
+  let activeFilterTagIds = [];
 
   /**
    * Find missing scenes for the current entity (paginated)
@@ -434,6 +435,7 @@
       const item = coreCreateSceneCard(scene, {
         stashdbUrl: stashdbUrl,
         whisparrConfigured: whisparrConfigured,
+        activeFilterTagIds: activeFilterTagIds,
         onWhisparrAdd: (scene, success, error) => {
           if (success) {
             setStatus(`Added "${scene.title}" to Whisparr`, "success");
@@ -692,6 +694,7 @@
 
       whisparrConfigured = result.whisparr_configured || false;
       stashdbUrl = result.stashdb_url || "https://stashdb.org";
+      activeFilterTagIds = result.active_filter_tag_ids || [];
 
       // Update pagination state
       currentCursor = result.cursor;

--- a/plugins/missingScenes/missing_scenes.py
+++ b/plugins/missingScenes/missing_scenes.py
@@ -1730,6 +1730,7 @@ def find_missing_scenes_paginated(entity_type, entity_id, plugin_settings,
         "whisparr_configured": whisparr_configured,
         "filters_active": filters_active,
         "active_filters": active_filters,
+        "active_filter_tag_ids": list(favorite_tag_ids) if favorite_tag_ids else [],
         "excluded_tags_applied": len(excluded_tag_ids) > 0
     }
 
@@ -1773,6 +1774,13 @@ def format_scene(scene, stash_id):
     urls = scene.get("urls", [])
     primary_url = urls[0].get("url") if urls else None
 
+    # Format tags
+    tags = [
+        {"id": t.get("id"), "name": t.get("name")}
+        for t in scene.get("tags", [])
+        if t.get("id") and t.get("name")
+    ]
+
     return {
         "stash_id": stash_id,
         "title": scene.get("title") or "Unknown Title",
@@ -1784,6 +1792,7 @@ def format_scene(scene, stash_id):
         "thumbnail": thumbnail,
         "studio": studio_info,
         "performers": performers,
+        "tags": tags,
         "url": primary_url
     }
 
@@ -2012,6 +2021,7 @@ def browse_stashdb(plugin_settings, page_size=50, cursor=None, sort="DATE", dire
         "missing_scenes": formatted_scenes,
         "whisparr_configured": whisparr_configured,
         "filters_active": filters_active,
+        "active_filter_tag_ids": list(tag_ids) if tag_ids else [],
         "excluded_tags_applied": len(excluded_tag_ids) > 0
     }
 


### PR DESCRIPTION
## Summary
- Display matching favorite tags as pill badges on scene cards when the tag filter is active
- Tags appear below performers on each card, only showing tags that match the active filter

## Notes
Tag data was already fetched from StashDB but dropped by `format_scene()`. Now it's passed through to the frontend, which cross-references against the active filter tag IDs to show only relevant matches.

Closes #100