### PR TITLE
feat(missingScenes): loading progress and cache timing display

### DIFF
--- a/plugins/missingScenes/missing-scenes-browse.js
+++ b/plugins/missingScenes/missing-scenes-browse.js
@@ -95,10 +95,10 @@
       if (stats.excluded_tags_applied) statsText += " (content filtered)";
       if (stats.cache_info) {
         const ci = stats.cache_info;
-        if (ci.source === "disk") {
-          statsText += ` | Index: ${ci.count.toLocaleString()} scenes (cached)`;
-        } else if (ci.source === "built") {
+        if (ci.source === "built") {
           statsText += ` | Index: ${ci.count.toLocaleString()} scenes (built in ${(ci.build_time_ms / 1000).toFixed(1)}s)`;
+        } else if (ci.source !== "unknown") {
+          statsText += ` | Index: ${ci.count.toLocaleString()} scenes (cached)`;
         }
       }
     }
@@ -110,7 +110,7 @@
         <div class="ms-placeholder">
           <div class="ms-spinner"></div>
           <div>Loading missing scenes...</div>
-          <div class="ms-loading-detail">Building scene index (first load may take a moment)</div>
+          <div class="ms-loading-detail">Building scene index (this may take a moment)</div>
         </div>
       `;
     } else if (loading && scenes.length > 0) {

--- a/plugins/missingScenes/missing-scenes-browse.js
+++ b/plugins/missingScenes/missing-scenes-browse.js
@@ -93,12 +93,29 @@
       statsText += " missing scenes";
       if (stats.filters_active) statsText += " (filtered)";
       if (stats.excluded_tags_applied) statsText += " (content filtered)";
+      if (stats.cache_info) {
+        const ci = stats.cache_info;
+        if (ci.source === "disk") {
+          statsText += ` | Index: ${ci.count.toLocaleString()} scenes (cached)`;
+        } else if (ci.source === "built") {
+          statsText += ` | Index: ${ci.count.toLocaleString()} scenes (built in ${(ci.build_time_ms / 1000).toFixed(1)}s)`;
+        }
+      }
     }
 
     // Build results content - placeholder for now, will be replaced with DOM elements
     let resultsPlaceholder;
     if (loading && scenes.length === 0) {
-      resultsPlaceholder = '<div class="ms-placeholder">Loading...</div>';
+      resultsPlaceholder = `
+        <div class="ms-placeholder">
+          <div class="ms-spinner"></div>
+          <div>Loading missing scenes...</div>
+          <div class="ms-loading-detail">Building scene index (first load may take a moment)</div>
+        </div>
+      `;
+    } else if (loading && scenes.length > 0) {
+      // Loading more - don't replace existing content, just show in footer
+      resultsPlaceholder = '';
     } else if (error) {
       resultsPlaceholder = `
         <div class="ms-placeholder ms-error">
@@ -246,6 +263,7 @@
           is_complete: result.is_complete,
           filters_active: result.filters_active,
           excluded_tags_applied: result.excluded_tags_applied,
+          cache_info: result.cache_info || null,
         }
       });
 

--- a/plugins/missingScenes/missing-scenes.css
+++ b/plugins/missingScenes/missing-scenes.css
@@ -713,6 +713,13 @@
   vertical-align: middle;
 }
 
+/* Loading detail text */
+.ms-loading-detail {
+  font-size: 12px;
+  color: #666;
+  margin-top: -8px;
+}
+
 /* Responsive adjustments for browse page */
 @media (max-width: 768px) {
   .ms-browse-controls {

--- a/plugins/missingScenes/missing_scenes.py
+++ b/plugins/missingScenes/missing_scenes.py
@@ -1128,6 +1128,16 @@ def get_or_build_cache(endpoint: str) -> set[str]:
     return stash_ids
 
 
+def _get_cache_info(endpoint: str) -> dict:
+    """Get cache metadata for API responses."""
+    meta = _cache_metadata.get(endpoint, {})
+    return {
+        "source": meta.get("source", "unknown"),
+        "count": meta.get("count", 0),
+        "build_time_ms": meta.get("build_time_ms", 0),
+    }
+
+
 def count_local_scenes_for_entity(endpoint: str, entity_type: str, entity_id: str) -> int:
     """Count local scenes that match an entity AND have a stash_id for the endpoint.
 

--- a/plugins/missingScenes/missing_scenes.py
+++ b/plugins/missingScenes/missing_scenes.py
@@ -1073,6 +1073,7 @@ def get_or_build_cache(endpoint: str) -> set[str]:
     stash_ids = set()
     page = 1
     per_page = 100
+    build_start = time.time()
 
     while True:
         result = stash_graphql("""
@@ -1114,6 +1115,7 @@ def get_or_build_cache(endpoint: str) -> set[str]:
 
     # Save to both memory and disk
     _local_stash_id_cache[endpoint] = stash_ids
+    build_time_ms = int((time.time() - build_start) * 1000)
     _cache_metadata[endpoint] = {
         "count": len(stash_ids),
         "built_at": datetime.now().isoformat(),


### PR DESCRIPTION
## Summary
- Add spinner and explanatory text during initial load ("Building scene index...")
- Display cache build timing in stats bar (e.g. "Index: 2,400 scenes (built in 3.2s)")
- Show "(cached)" for subsequent loads served from memory/disk cache
- Don't wipe existing results when loading more pages

## Context
Part of pagination UX improvements prompted by https://discourse.stashapp.cc/t/missing-scenes/4620/18

## Test plan
- [ ] Deploy to stash-test, open Missing Scenes browse page
- [ ] Verify spinner and "Building scene index" text appears during first load
- [ ] After results load, check stats bar shows index count and build timing
- [ ] Click Load More — existing cards should stay visible during load
- [ ] On second visit (within 5 min if cache-persistence PR merged), stats should show "(cached)"

🤖 Generated with [Claude Code](https://claude.com/claude-code)