### PR TITLE
feat(performerImageSearch): add preview navigation1

### DIFF
--- a/plugins/performerImageSearch/performer-image-search.css
+++ b/plugins/performerImageSearch/performer-image-search.css
@@ -300,6 +300,8 @@
   max-height: calc(90vh - 80px);
   object-fit: contain;
   border-radius: 4px;
+  user-select: none;
+  -webkit-user-drag: none;
 }
 
 .pis-preview-dims {

--- a/plugins/performerImageSearch/performer-image-search.js
+++ b/plugins/performerImageSearch/performer-image-search.js
@@ -48,6 +48,7 @@
   let loadedCount = 0; // Number of images that have loaded
   let isLoading = false;
   let previewImage = null;
+  let currentPreviewIndex = -1;
   let seenImageUrls = new Set(); // For deduplication across sources
   let completedSources = []; // Track which sources have completed
   let pendingSources = []; // Track which sources are still loading
@@ -297,6 +298,7 @@
     imageDimensions = {};
     loadedCount = 0;
     previewImage = null;
+    currentPreviewIndex = -1;
     seenImageUrls = new Set();
     completedSources = [];
     pendingSources = [];
@@ -359,7 +361,7 @@
       <!-- Preview overlay -->
       <div id="pis-preview-overlay" class="pis-preview-overlay" style="display: none;" onclick="window.pisClosePreview()">
         <div class="pis-preview-content" onclick="event.stopPropagation()">
-          <img id="pis-preview-image" src="" alt="Preview" />
+          <img id="pis-preview-image" src="" alt="Preview" onclick="window.pisClickPreview(event)" />
           <div id="pis-preview-dims" class="pis-preview-dims"></div>
           <div class="pis-preview-actions">
             <button id="pis-confirm-btn" class="pis-btn pis-btn-primary" onclick="window.pisConfirmImage()">Set as Performer Image</button>
@@ -389,6 +391,25 @@
         updateFilterStatus();
       }
     });
+
+    // Add keyboard navigation for preview
+    document.addEventListener("keydown", handlePreviewKeydown);
+  }
+
+  /**
+   * Handle keyboard navigation in preview
+   */
+  function handlePreviewKeydown(e) {
+    const overlay = document.getElementById("pis-preview-overlay");
+    if (!overlay || overlay.style.display === "none") return;
+
+    if (e.key === "ArrowLeft") {
+      window.pisPrevPreview();
+    } else if (e.key === "ArrowRight") {
+      window.pisNextPreview();
+    } else if (e.key === "Escape") {
+      window.pisClosePreview();
+    }
   }
 
   /**
@@ -563,6 +584,7 @@
     if (!result) return;
 
     previewImage = result.image;
+    currentPreviewIndex = originalIndex;
 
     const overlay = document.getElementById("pis-preview-overlay");
     const img = document.getElementById("pis-preview-image");
@@ -572,22 +594,57 @@
       // Clear previous dimensions
       if (dimInfo) dimInfo.textContent = "Loading...";
 
+      // Clear previous handlers by replacing img src
+      img.onload = null;
+      img.onerror = null;
+
       // Show dimensions once image loads
       img.onload = function () {
-        if (dimInfo) {
+        if (dimInfo && overlay.style.display !== "none") {
           dimInfo.textContent = `${img.naturalWidth} x ${img.naturalHeight} - ${result.source}`;
         }
       };
 
       // Try full-size first, fall back to thumbnail if it fails
       img.onerror = function () {
-        if (img.src !== result.thumbnail) {
+        if (img.src !== result.thumbnail && overlay.style.display !== "none") {
           img.src = result.thumbnail;
-          previewImage = result.thumbnail; // Update so we save the working URL
+          previewImage = result.thumbnail;
         }
       };
       img.src = result.image;
       overlay.style.display = "flex";
+    }
+  };
+
+  /**
+   * Handle click on preview image - navigate based on click position
+   */
+  window.pisClickPreview = function (e) {
+    const rect = e.target.getBoundingClientRect();
+    const x = e.clientX - rect.left;
+    if (x < rect.width / 2) {
+      window.pisPrevPreview();
+    } else {
+      window.pisNextPreview();
+    }
+  };
+
+  /**
+   * Navigate to previous image in preview
+   */
+  window.pisPrevPreview = function () {
+    if (currentPreviewIndex > 0) {
+      window.pisShowPreview(currentPreviewIndex - 1);
+    }
+  };
+
+  /**
+   * Navigate to next image in preview
+   */
+  window.pisNextPreview = function () {
+    if (currentPreviewIndex < allResults.length - 1) {
+      window.pisShowPreview(currentPreviewIndex + 1);
     }
   };
 
@@ -600,6 +657,7 @@
       overlay.style.display = "none";
     }
     previewImage = null;
+    document.removeEventListener("keydown", handlePreviewKeydown);
   };
 
   /**

--- a/plugins/performerImageSearch/performer-image-search.js
+++ b/plugins/performerImageSearch/performer-image-search.js
@@ -657,7 +657,6 @@
       overlay.style.display = "none";
     }
     previewImage = null;
-    document.removeEventListener("keydown", handlePreviewKeydown);
   };
 
   /**


### PR DESCRIPTION
- Click left/right half of image to navigate
- Keyboard ←/→ to navigate, Esc to close
- Prevent selection highlight on fast clicks