### PR TITLE
feat(missingScenes): endpoint dropdown in modal and browse views

### DIFF
--- a/plugins/missingScenes/missing-scenes-browse.js
+++ b/plugins/missingScenes/missing-scenes-browse.js
@@ -13,10 +13,17 @@
   } = Core;
 
   /**
+   * Fetch all configured stash-box endpoints
+   */
+  async function getAllEndpoints() {
+    return runPluginOperation({ operation: "get_all_endpoints" });
+  }
+
+  /**
    * Browse StashDB for missing scenes
    */
   async function browseStashdb(options = {}) {
-    return runPluginOperation({
+    const args = {
       operation: "browse_stashdb",
       page_size: options.pageSize || pageSize,
       cursor: options.cursor || null,
@@ -25,7 +32,11 @@
       filter_favorite_performers: options.filterFavoritePerformers || false,
       filter_favorite_studios: options.filterFavoriteStudios || false,
       filter_favorite_tags: options.filterFavoriteTags || false,
-    });
+    };
+    if (selectedEndpoint) {
+      args.endpoint = selectedEndpoint;
+    }
+    return runPluginOperation(args);
   }
 
   // Page state (module-scoped for persistence)
@@ -42,6 +53,8 @@
   let pageSize = 50;
   let whisparrConfigured = false;
   let stashdbUrl = "";
+  let availableEndpoints = [];
+  let selectedEndpoint = null;
 
   /**
    * Set page title with retry to overcome Stash's title management
@@ -146,6 +159,20 @@
       }
     }
 
+    // Build endpoint dropdown (only if multiple endpoints configured)
+    let endpointDropdown = '';
+    if (availableEndpoints.length > 1) {
+      const epOptions = availableEndpoints.map(ep =>
+        `<option value="${ep.endpoint}" ${selectedEndpoint === ep.endpoint ? 'selected' : ''}>${escapeHtml(ep.name)}</option>`
+      ).join('');
+      endpointDropdown = `
+        <div class="ms-endpoint-selector ms-browse-endpoint-selector">
+          <label for="ms-endpoint-dropdown">Source:</label>
+          <select id="ms-endpoint-dropdown" class="ms-endpoint-dropdown">${epOptions}</select>
+        </div>
+      `;
+    }
+
     container.innerHTML = `
       <div class="ms-browse-page">
         <div class="ms-browse-header">
@@ -154,6 +181,7 @@
         </div>
 
         <div class="ms-browse-controls">
+          ${endpointDropdown}
           <div class="ms-filter-controls">
             <label class="ms-filter-checkbox">
               <input type="checkbox" id="ms-filter-performers" ${filterPerformersChecked}>
@@ -281,6 +309,12 @@
    * Setup control handlers (filters, sort, load more)
    */
   function setupControlHandlers(container) {
+    // Endpoint dropdown
+    container.querySelector('#ms-endpoint-dropdown')?.addEventListener('change', (e) => {
+      selectedEndpoint = e.target.value;
+      performSearch(container, true);
+    });
+
     // Filter checkboxes
     container.querySelector('#ms-filter-performers')?.addEventListener('change', (e) => {
       filterFavoritePerformers = e.target.checked;
@@ -338,6 +372,15 @@
         currentCursor = null;
         hasMore = true;
         isLoading = false;
+
+        // Fetch available endpoints before first search
+        try {
+          const epInfo = await getAllEndpoints();
+          availableEndpoints = epInfo.available_endpoints || [];
+          selectedEndpoint = epInfo.default_endpoint || (availableEndpoints[0]?.endpoint);
+        } catch (e) {
+          console.error("[MissingScenes] Failed to fetch endpoints:", e);
+        }
 
         // Initial render and load
         renderPage(containerRef.current, { loading: true, error: null, scenes: [], stats: null });

--- a/plugins/missingScenes/missing-scenes-browse.js
+++ b/plugins/missingScenes/missing-scenes-browse.js
@@ -163,7 +163,7 @@
     let endpointDropdown = '';
     if (availableEndpoints.length > 1) {
       const epOptions = availableEndpoints.map(ep =>
-        `<option value="${ep.endpoint}" ${selectedEndpoint === ep.endpoint ? 'selected' : ''}>${escapeHtml(ep.name)}</option>`
+        `<option value="${escapeHtml(ep.endpoint)}" ${selectedEndpoint === ep.endpoint ? 'selected' : ''}>${escapeHtml(ep.name)}</option>`
       ).join('');
       endpointDropdown = `
         <div class="ms-endpoint-selector ms-browse-endpoint-selector">

--- a/plugins/missingScenes/missing-scenes.css
+++ b/plugins/missingScenes/missing-scenes.css
@@ -471,7 +471,7 @@
   }
 }
 
-/* Endpoint selector for tags with multiple stash-box links */
+/* Endpoint selector for entities with multiple stash-box links */
 .ms-endpoint-selector {
   display: flex;
   align-items: center;
@@ -479,6 +479,13 @@
   padding: 0.5rem 1rem;
   background: var(--ms-bg-secondary, #1a1a1a);
   border-bottom: 1px solid var(--ms-border, #333);
+}
+
+/* Browse page endpoint selector - no bottom border, integrates with controls */
+.ms-browse-endpoint-selector {
+  border-bottom: none;
+  padding: 0;
+  background: none;
 }
 
 .ms-endpoint-selector label {

--- a/plugins/missingScenes/missing-scenes.js
+++ b/plugins/missingScenes/missing-scenes.js
@@ -291,7 +291,7 @@
     container.id = "ms-endpoint-selector";
 
     const label = document.createElement("label");
-    label.textContent = "Search on: ";
+    label.textContent = "Source: ";
     label.htmlFor = "ms-endpoint-dropdown";
 
     const select = document.createElement("select");

--- a/plugins/missingScenes/missing-scenes.js
+++ b/plugins/missingScenes/missing-scenes.js
@@ -22,7 +22,7 @@
   let whisparrConfigured = false;
   let stashdbUrl = "";
 
-  // Endpoint selection state (for tags with multiple stash-box links)
+  // Endpoint selection state (for entities with multiple stash-box links)
   let availableEndpoints = []; // [{endpoint, name, stash_id}]
   let selectedEndpoint = null;
 
@@ -614,44 +614,38 @@
     setStatus("Checking endpoints...", "loading");
 
     try {
-      // For tags, check available endpoints first
-      if (currentEntityType === "tag") {
-        const endpointInfo = await getEndpoints(currentEntityType, currentEntityId);
-        availableEndpoints = endpointInfo.available_endpoints || [];
-        selectedEndpoint = endpointInfo.default_endpoint;
+      // Check available endpoints for this entity
+      const endpointInfo = await getEndpoints(currentEntityType, currentEntityId);
+      availableEndpoints = endpointInfo.available_endpoints || [];
+      selectedEndpoint = endpointInfo.default_endpoint;
 
-        if (availableEndpoints.length === 0) {
-          showError(`This tag is not linked to any configured stash-box. Please link it first.`);
-          setStatus("Tag not linked to stash-box", "error");
-          isLoading = false;
-          return;
-        }
-
-        // Show endpoint selector if multiple valid endpoints and no clear default
-        if (availableEndpoints.length > 1 && !endpointInfo.default_endpoint) {
-          // Insert selector into modal header
-          const statsEl = document.getElementById("ms-stats");
-          if (statsEl) {
-            const selector = createEndpointSelector(
-              availableEndpoints,
-              availableEndpoints[0].endpoint,
-              (newEndpoint) => {
-                // Re-run search with new endpoint
-                selectedEndpoint = newEndpoint;
-                performSearch();
-              }
-            );
-            statsEl.parentNode.insertBefore(selector, statsEl);
-          }
-          selectedEndpoint = availableEndpoints[0].endpoint;
-        }
-      } else {
-        // For performers/studios, clear endpoint state
-        availableEndpoints = [];
-        selectedEndpoint = null;
+      if (availableEndpoints.length === 0) {
+        showError(`This ${currentEntityType} is not linked to any configured stash-box. Add a StashDB link first.`);
+        setStatus("Not linked to stash-box", "error");
+        isLoading = false;
+        return;
       }
 
-      await performSearch();
+      // Show endpoint selector if multiple endpoints available
+      if (availableEndpoints.length > 1) {
+        const statsEl = document.getElementById("ms-stats");
+        if (statsEl) {
+          const selector = createEndpointSelector(
+            availableEndpoints,
+            selectedEndpoint || availableEndpoints[0].endpoint,
+            (newEndpoint) => {
+              selectedEndpoint = newEndpoint;
+              performSearch(true);
+            }
+          );
+          statsEl.parentNode.insertBefore(selector, statsEl);
+        }
+        if (!selectedEndpoint) {
+          selectedEndpoint = availableEndpoints[0].endpoint;
+        }
+      }
+
+      await performSearch(true);
     } catch (error) {
       console.error("[MissingScenes] Search failed:", error);
       showError(error.message || "Failed to search for missing scenes");

--- a/plugins/missingScenes/missingScenes.yml
+++ b/plugins/missingScenes/missingScenes.yml
@@ -17,8 +17,8 @@ ui:
 settings:
   # Stash-box endpoint selection
   stashBoxEndpoint:
-    displayName: Stash-Box Endpoint
-    description: Which stash-box to query for missing scenes. Leave empty to use the first configured endpoint (usually StashDB). Enter the full GraphQL URL (e.g., https://stashdb.org/graphql).
+    displayName: Default Stash-Box Endpoint
+    description: Default stash-box endpoint selected in the UI dropdown. Leave empty to use the first configured endpoint. Enter the full GraphQL URL (e.g., https://stashdb.org/graphql).
     type: STRING
 
   # Whisparr integration (optional)

--- a/plugins/missingScenes/missing_scenes.py
+++ b/plugins/missingScenes/missing_scenes.py
@@ -2689,7 +2689,6 @@ def main():
                         "entity_name": entity.get("name"),
                         "available_endpoints": available,
                         "default_endpoint": default_endpoint,
-                        "show_selector": len(available) > 1
                     }
 
         elif operation == "get_all_endpoints":

--- a/plugins/missingScenes/missing_scenes.py
+++ b/plugins/missingScenes/missing_scenes.py
@@ -1887,7 +1887,8 @@ def format_scene(scene, stash_id):
     }
 
 
-def browse_stashdb(plugin_settings, page_size=50, cursor=None, sort="DATE", direction="DESC",
+def browse_stashdb(plugin_settings, endpoint_override=None, page_size=50, cursor=None,
+                   sort="DATE", direction="DESC",
                    filter_favorite_performers=False, filter_favorite_studios=False,
                    filter_favorite_tags=False):
     """
@@ -1895,6 +1896,7 @@ def browse_stashdb(plugin_settings, page_size=50, cursor=None, sort="DATE", dire
 
     Args:
         plugin_settings: Plugin configuration
+        endpoint_override: Optional endpoint URL to use (from UI dropdown)
         page_size: Number of missing scenes per page
         cursor: Pagination cursor
         sort: Sort field
@@ -1921,8 +1923,8 @@ def browse_stashdb(plugin_settings, page_size=50, cursor=None, sort="DATE", dire
     if not stashbox_configs:
         return {"error": "No stash-box endpoints configured in Stash settings"}
 
-    # Use configured or first endpoint
-    target_endpoint = plugin_settings.get("stashBoxEndpoint", "").strip()
+    # Use endpoint override, configured default, or first endpoint
+    target_endpoint = endpoint_override or plugin_settings.get("stashBoxEndpoint", "").strip()
     stashbox = None
 
     if target_endpoint:
@@ -2616,6 +2618,7 @@ def main():
                 output = find_missing_scenes(entity_type, entity_id, plugin_settings, endpoint_override=endpoint)
 
         elif operation == "browse_stashdb":
+            endpoint = args.get("endpoint")
             page_size = args.get("page_size", PAGE_SIZE_DEFAULT)
             cursor = args.get("cursor")
             sort = args.get("sort", "DATE")
@@ -2626,6 +2629,7 @@ def main():
 
             output = browse_stashdb(
                 plugin_settings=plugin_settings,
+                endpoint_override=endpoint,
                 page_size=page_size,
                 cursor=cursor,
                 sort=sort,
@@ -2685,8 +2689,33 @@ def main():
                         "entity_name": entity.get("name"),
                         "available_endpoints": available,
                         "default_endpoint": default_endpoint,
-                        "show_selector": len(available) > 1 and not default_endpoint
+                        "show_selector": len(available) > 1
                     }
+
+        elif operation == "get_all_endpoints":
+            configured_boxes = get_stashbox_config()
+            preferred = plugin_settings.get("stashBoxEndpoint", "").strip()
+
+            endpoints = []
+            for box in configured_boxes:
+                endpoints.append({
+                    "endpoint": box["endpoint"],
+                    "name": box.get("name", box["endpoint"]),
+                })
+
+            default_endpoint = None
+            if preferred:
+                for ep in endpoints:
+                    if ep["endpoint"] == preferred:
+                        default_endpoint = preferred
+                        break
+            if not default_endpoint and endpoints:
+                default_endpoint = endpoints[0]["endpoint"]
+
+            output = {
+                "available_endpoints": endpoints,
+                "default_endpoint": default_endpoint,
+            }
 
         elif operation:
             output = {"error": f"Unknown operation: {operation}"}


### PR DESCRIPTION
## Summary
- Adds a dynamic stash-box endpoint dropdown to both the modal (performer/studio/tag pages) and the browse page (`/plugins/missing-scenes`)
- Modal shows the dropdown when an entity is linked to 2+ configured stash-box endpoints — previously only worked for tags
- Browse page shows all configured endpoints, letting users switch which stash-box they're browsing
- The `stashBoxEndpoint` plugin setting now serves as the default dropdown selection rather than the sole endpoint choice
- New `get_all_endpoints` backend operation returns all configured stash-box endpoints for the browse page

## Test plan
- [ ] Modal on performer with 1 endpoint — no dropdown shown, works as before
- [ ] Modal on performer/studio with 2+ endpoints — dropdown shown, switching re-searches
- [ ] Browse page with multiple endpoints — dropdown at top of controls, switching resets and re-searches
- [ ] Default endpoint setting pre-selects correct option in both views
- [ ] ThePornDB endpoint works via browse dropdown (REST adapter)
- [ ] Single endpoint configured — no dropdown shown anywhere

🤖 Generated with [Claude Code](https://claude.com/claude-code)