### PR TITLE
Tag Manager: Fix settings page showing wrong values, fix parent tags deleting all settings & centralize default settings

### DIFF
--- a/plugins/tagManager/default_settings.json
+++ b/plugins/tagManager/default_settings.json
@@ -1,0 +1,11 @@
+{
+  "enableFuzzySearch": true,
+  "enableSynonymSearch": true,
+  "fuzzyThreshold": 80,
+  "pageSize": 25,
+  "preferStashBoxName": false,
+  "preferStashBoxDescription": false,
+  "syncDryRun": true,
+  "categoryMappings": "{}",
+  "tagBlacklist": ""
+}

--- a/plugins/tagManager/tag-manager.js
+++ b/plugins/tagManager/tag-manager.js
@@ -5,20 +5,14 @@
   const ROUTE_PATH = "/plugins/tag-manager";
   const HIERARCHY_ROUTE_PATH = "/plugins/tag-hierarchy";
 
-  // Default settings
-  const DEFAULTS = {
-    stashdbEndpoint: "https://stashdb.org/graphql",
-    stashdbApiKey: "",
-    enableFuzzySearch: true,
-    enableSynonymSearch: true,
-    fuzzyThreshold: 80,
-    pageSize: 25,
-    preferStashBoxName: false,
-    preferStashBoxDescription: false,
-  };
+  const STASHDB_ENDPOINT = "https://stashdb.org/graphql";
+  const STASHDB_API_KEY = "";
+
+  // Default settings are loaded from shared default_settings.json.
+  let DEFAULTS = {};
 
   // State
-  let settings = { ...DEFAULTS };
+  let settings = {};
   let stashBoxes = []; // Configured stash-box endpoints from Stash
   let selectedStashBox = null; // Currently selected stash-box
   let stashdbTags = null; // Cached tags for selected endpoint
@@ -61,6 +55,16 @@
   }
 
   /**
+   * Get URL for a plugin asset file.
+   */
+  function getPluginAssetUrl(assetPath) {
+    const baseEl = document.querySelector("base");
+    const baseURL = baseEl ? baseEl.getAttribute("href") : "/";
+    const normalizedAssetPath = assetPath.replace(/^\/+/, "");
+    return `${baseURL}plugin/${PLUGIN_ID}/assets/${normalizedAssetPath}`;
+  }
+
+  /**
    * Make a GraphQL request to local Stash
    */
   async function graphqlRequest(query, variables = {}) {
@@ -90,6 +94,88 @@
   }
 
   /**
+   * Load plugin config map from stash
+   */
+  async function getPluginConfig() {
+    const query = `
+      query Configuration {
+        configuration {
+          plugins
+        }
+      }
+    `;
+    const data = await graphqlRequest(query);
+    return data?.configuration?.plugins?.[PLUGIN_ID] || {};
+  }
+
+  /**
+   * Merge `partialInput` into the current plugin settings and persist.
+   *
+   * Stash overwrites `plugins.settings.<pluginId>` on each `configurePlugin` call,
+   * so we load the existing map, shallow-merge, then send the full object.
+   *
+   * @param {Record<string, unknown>} partialInput
+   * @returns {Promise<Record<string, unknown>>} The saved settings map
+   */
+  async function savePluginConfigPatch(partialInput) {
+    const current = await getPluginConfig();
+
+    // Merge new settings with existing settings
+    const next = { ...current, ...partialInput };
+
+    // Send the full object to the backend
+    const mutation = `
+      mutation ConfigurePlugin($plugin_id: ID!, $input: Map!) {
+        configurePlugin(plugin_id: $plugin_id, input: $input)
+      }
+    `;
+    await graphqlRequest(mutation, {
+      plugin_id: PLUGIN_ID,
+      input: next,
+    });
+
+    return next;
+  }
+
+  /**
+   * Bootstrap plugin defaults from `default_settings.json`.
+   *
+   * This runs once during startup, caches the defaults in memory, and backfills
+   * only missing keys in Stash plugin configuration. Existing user values are
+   * preserved.
+   */
+  async function initializeDefaultSettings() {
+    // Load default settings
+    const response = await fetch(getPluginAssetUrl("default_settings.json"), {
+      method: "GET",
+      cache: "no-store",
+    });
+    if (!response.ok) {
+      throw new Error(`Failed to fetch default settings file: ${response.status}`);
+    }
+
+    DEFAULTS = await response.json();
+    if (Object.keys(settings).length === 0) {
+      settings = { ...DEFAULTS };
+    }
+
+    // Compute keys that are missing in stash settings
+    const pluginConfig = await getPluginConfig();
+    const missingDefaults = {};
+    for (const [key, value] of Object.entries(DEFAULTS)) {
+      if (pluginConfig[key] === undefined || pluginConfig[key] === null) {
+        missingDefaults[key] = value;
+      }
+    }
+
+    // Add missing defaults to stash settings without overwriting existing user values
+    if (Object.keys(missingDefaults).length > 0) {
+      await savePluginConfigPatch(missingDefaults);
+      console.info("[tagManager] Persisted missing defaults:", Object.keys(missingDefaults));
+    }
+  }
+
+  /**
    * Get plugin settings and stash-box endpoints from Stash configuration
    */
   async function loadSettings() {
@@ -112,14 +198,14 @@
       const pluginConfig = data?.configuration?.plugins?.[PLUGIN_ID] || {};
 
       settings = {
-        stashdbEndpoint: pluginConfig.stashdbEndpoint || DEFAULTS.stashdbEndpoint,
-        stashdbApiKey: pluginConfig.stashdbApiKey || DEFAULTS.stashdbApiKey,
-        enableFuzzySearch: pluginConfig.enableFuzzySearch !== false,
-        enableSynonymSearch: pluginConfig.enableSynonymSearch !== false,
+        stashdbEndpoint: pluginConfig.stashdbEndpoint || STASHDB_ENDPOINT,
+        stashdbApiKey: pluginConfig.stashdbApiKey || STASHDB_API_KEY,
+        enableFuzzySearch: pluginConfig.enableFuzzySearch ?? DEFAULTS.enableFuzzySearch,
+        enableSynonymSearch: pluginConfig.enableSynonymSearch ?? DEFAULTS.enableSynonymSearch,
         fuzzyThreshold: parseInt(pluginConfig.fuzzyThreshold) || DEFAULTS.fuzzyThreshold,
         pageSize: parseInt(pluginConfig.pageSize) || DEFAULTS.pageSize,
-        preferStashBoxName: pluginConfig.preferStashBoxName === true,
-        preferStashBoxDescription: pluginConfig.preferStashBoxDescription === true,
+        preferStashBoxName: pluginConfig.preferStashBoxName ?? DEFAULTS.preferStashBoxName,
+        preferStashBoxDescription: pluginConfig.preferStashBoxDescription ?? DEFAULTS.preferStashBoxDescription,
       };
 
       // Load configured stash-boxes
@@ -185,17 +271,8 @@
    */
   async function saveCategoryMappings() {
     try {
-      const query = `
-        mutation ConfigurePlugin($plugin_id: ID!, $input: Map!) {
-          configurePlugin(plugin_id: $plugin_id, input: $input)
-        }
-      `;
-
-      await graphqlRequest(query, {
-        plugin_id: PLUGIN_ID,
-        input: {
-          categoryMappings: JSON.stringify(categoryMappings)
-        }
+      await savePluginConfigPatch({
+        categoryMappings: JSON.stringify(categoryMappings)
       });
       console.debug("[tagManager] Saved category mappings");
     } catch (e) {
@@ -4517,6 +4594,7 @@
   }
 
   // Initialize
+  initializeDefaultSettings();
   registerRoute();
   setupNavButtonInjection();
   console.log('[tagManager] Plugin loaded');

--- a/plugins/tagManager/tagManager.yml
+++ b/plugins/tagManager/tagManager.yml
@@ -1,6 +1,6 @@
 name: Tag Manager
 description: Match and sync local tags with stash-box endpoints. Features multi-endpoint support, tag caching, layered search (exact, fuzzy, synonym), and field-by-field merge dialog.
-version: 0.4.0
+version: 0.4.1
 url: https://github.com/carrotwaxr/stash-plugins
 
 ui:
@@ -8,6 +8,8 @@ ui:
     - tag-manager.js
   css:
     - tag-manager.css
+  assets:
+    /: .
 
 settings:
   enableFuzzySearch:

--- a/plugins/tagManager/tag_manager.py
+++ b/plugins/tagManager/tag_manager.py
@@ -18,7 +18,6 @@ import sys
 import time
 
 import log
-from stashapi.stashapp import StashInterface
 from stashdb_api import search_tags_by_name, query_all_tags
 from matcher import TagMatcher, load_synonyms
 from blacklist import Blacklist
@@ -33,6 +32,26 @@ CACHE_MAX_AGE_HOURS = 24  # Cache expires after 24 hours
 def get_plugin_dir():
     """Get the plugin directory path."""
     return os.path.dirname(os.path.abspath(__file__))
+
+
+def load_default_settings():
+    """
+    Load canonical plugin defaults from shared JSON file.
+
+    Returns:
+        Dict with default plugin settings.
+    """
+    defaults_path = os.path.join(get_plugin_dir(), "default_settings.json")
+    try:
+        with open(defaults_path, 'r', encoding='utf-8') as f:
+            return json.load(f)
+    except (OSError, json.JSONDecodeError) as e:
+        raise RuntimeError(f"Failed to load default settings file '{defaults_path}': {e}") from e
+
+
+# Canonical plugin defaults (single source of truth for Python + JS).
+# Note: tagManager.yml settings schema does not support "default" fields.
+DEFAULT_PLUGIN_SETTINGS = load_default_settings()
 
 
 def get_cache_dir():
@@ -212,13 +231,15 @@ def get_settings_from_config(stash_config):
     config = stash_config or {}
 
     return {
+        # Legacy plugin-level stashdbEndpoint/stashdbApiKey are intentionally
+        # not part of YAML defaults. Stash-box endpoints are preferred.
         "stashdb_url": config.get("stashdbEndpoint", "https://stashdb.org/graphql"),
         "stashdb_api_key": config.get("stashdbApiKey", ""),
-        "enable_fuzzy": config.get("enableFuzzySearch") != False,  # Default True
-        "enable_synonyms": config.get("enableSynonymSearch") != False,  # Default True
-        "fuzzy_threshold": int(config.get("fuzzyThreshold", 80)),
-        "page_size": int(config.get("pageSize", 25)),
-        "tag_blacklist": config.get("tagBlacklist", ""),
+        "enable_fuzzy": config.get("enableFuzzySearch", DEFAULT_PLUGIN_SETTINGS["enableFuzzySearch"]),
+        "enable_synonyms": config.get("enableSynonymSearch", DEFAULT_PLUGIN_SETTINGS["enableSynonymSearch"]),
+        "fuzzy_threshold": int(config.get("fuzzyThreshold", DEFAULT_PLUGIN_SETTINGS["fuzzyThreshold"])),
+        "page_size": int(config.get("pageSize", DEFAULT_PLUGIN_SETTINGS["pageSize"])),
+        "tag_blacklist": config.get("tagBlacklist", DEFAULT_PLUGIN_SETTINGS["tagBlacklist"]),
     }
 
 
@@ -239,26 +260,26 @@ def handle_search(tag_name, stashdb_url, stashdb_api_key, settings, stashdb_tags
     log.LogDebug(f"Searching for tag: {tag_name}")
 
     # Load blacklist from settings
-    blacklist = Blacklist(settings.get('tag_blacklist', ''))
+    blacklist = Blacklist(settings["tag_blacklist"])
 
     # First try StashDB's name search (searches name + aliases)
     api_matches = search_tags_by_name(stashdb_url, stashdb_api_key, tag_name, limit=20)
 
     # If we have cached tags, also do local fuzzy matching
     local_matches = []
-    if stashdb_tags and settings.get("enable_fuzzy", True):
+    if stashdb_tags and settings["enable_fuzzy"]:
         synonyms_path = os.path.join(get_plugin_dir(), "synonyms.json")
         synonyms = load_synonyms(synonyms_path)
 
         matcher = TagMatcher(
             stashdb_tags,
             synonyms=synonyms,
-            fuzzy_threshold=settings.get("fuzzy_threshold", 80)
+            fuzzy_threshold=settings["fuzzy_threshold"]
         )
         local_matches = matcher.find_matches(
             tag_name,
-            enable_fuzzy=settings.get("enable_fuzzy", True),
-            enable_synonyms=settings.get("enable_synonyms", True),
+            enable_fuzzy=settings["enable_fuzzy"],
+            enable_synonyms=settings["enable_synonyms"],
             limit=20
         )
 
@@ -406,6 +427,7 @@ def handle_sync_scene_tags(server_connection, stash_config, api_key):
         Dict with sync results
     """
     from stashdb_scene_sync import sync_scene_tags
+    from stashapi.stashapp import StashInterface
 
     # Initialize Stash interface with API key for long-running operations
     # Session cookies can expire during long sync operations (see stash#5332)
@@ -435,11 +457,8 @@ def handle_sync_scene_tags(server_connection, stash_config, api_key):
     log.LogInfo(f"Using stash-box endpoint: {stashdb_url}")
 
     # Get dry_run setting from plugin config
-    try:
-        plugin_config = stash_config.get("plugins", {}).get(PLUGIN_ID, {})
-        dry_run = plugin_config.get("syncDryRun", True)  # Default to safe mode
-    except Exception:
-        dry_run = True
+    plugin_config = stash_config.get("plugins", {}).get(PLUGIN_ID, {})
+    dry_run = plugin_config.get("syncDryRun", DEFAULT_PLUGIN_SETTINGS["syncDryRun"])
 
     sync_settings = {
         "dry_run": dry_run
@@ -514,6 +533,9 @@ def main():
 
     if mode == "sync_scene_tags":
         log.LogInfo("Starting scene tag sync task")
+        
+        from stashapi.stashapp import StashInterface
+        
         # Get stash config for stash-box credentials and API key
         stash = StashInterface(server_connection)
         try:

--- a/plugins/tagManager/tests/test_default_settings_file.py
+++ b/plugins/tagManager/tests/test_default_settings_file.py
@@ -1,0 +1,149 @@
+"""
+Tests for shared default_settings.json integrity.
+
+Requires pyyaml:
+  python -m pip install pyyaml
+
+Run:
+  python -m unittest tests.test_default_settings_file
+"""
+import json
+import os
+import unittest
+import yaml
+
+
+def _defaults_path():
+    tests_dir = os.path.dirname(os.path.abspath(__file__))
+    plugin_dir = os.path.dirname(tests_dir)
+    return os.path.join(plugin_dir, "default_settings.json")
+
+
+def _plugin_yml_path():
+    tests_dir = os.path.dirname(os.path.abspath(__file__))
+    plugin_dir = os.path.dirname(tests_dir)
+    return os.path.join(plugin_dir, "tagManager.yml")
+
+
+def _format_json_error(path, err: json.JSONDecodeError) -> str:
+    """Single readable block for invalid JSON (avoids long decoder tracebacks)."""
+    doc = err.doc or ""
+    start = max(0, err.pos - 50)
+    end = min(len(doc), err.pos + 50)
+    snippet = doc[start:end].replace("\n", "\\n")
+    pointer = " " * max(0, err.pos - start) + "^"
+    return (
+        f"Invalid JSON in {path}\n"
+        f"  Line {err.lineno}, column {err.colno}: {err.msg}\n"
+        f"  Context: ...{snippet!s}...\n"
+        f"           {pointer}"
+    )
+
+
+class TestDefaultSettingsFile(unittest.TestCase):
+    """Validate default_settings.json shape and value types."""
+
+    maxDiff = None
+
+    @staticmethod
+    def _raise_parse_error(msg: str) -> None:
+        """Fail the test without chaining the original parser exception (cleaner unittest output)."""
+        raise AssertionError(msg) from None
+
+    def _load_defaults(self):
+        path = _defaults_path()
+        try:
+            with open(path, "r", encoding="utf-8") as f:
+                raw = f.read()
+        except OSError as e:
+            self._raise_parse_error(f"Cannot read default settings file:\n  {path}\n  {e}")
+
+        try:
+            data = json.loads(raw)
+        except json.JSONDecodeError as e:
+            self._raise_parse_error(_format_json_error(path, e))
+
+        if not isinstance(data, dict):
+            self.fail(
+                f"default_settings.json must be a JSON object {{ ... }}, got {type(data).__name__}\n"
+                f"  File: {path}"
+            )
+        return data
+
+    def _load_settings_schema_from_plugin_yml(self):
+        path = _plugin_yml_path()
+        try:
+            with open(path, "r", encoding="utf-8") as f:
+                plugin_cfg = yaml.safe_load(f) or {}
+        except yaml.YAMLError as e:
+            self._raise_parse_error(f"Invalid YAML in tagManager.yml:\n  {path}\n  {e}")
+        except OSError as e:
+            self._raise_parse_error(f"Cannot read tagManager.yml:\n  {path}\n  {e}")
+
+        settings = plugin_cfg.get("settings") or {}
+        if not isinstance(settings, dict):
+            self.fail(f"tagManager.yml 'settings' must be a mapping, got {type(settings).__name__}")
+
+        schema = {}
+        for key, meta in settings.items():
+            if not isinstance(meta, dict):
+                self.fail(
+                    f"tagManager.yml settings.{key} must be a mapping with a 'type' field, "
+                    f"got {type(meta).__name__}"
+                )
+            t = meta.get("type")
+            if not t:
+                self.fail(f"tagManager.yml settings.{key} is missing 'type'")
+            schema[key] = t
+        return schema
+
+    def test_default_settings_is_well_formed(self):
+        """Shared defaults file should contain all required keys with expected types."""
+        defaults = self._load_defaults()
+        settings_schema = self._load_settings_schema_from_plugin_yml()
+
+        required_keys = set(settings_schema.keys())
+        actual_keys = set(defaults.keys())
+        if actual_keys != required_keys:
+            missing = sorted(required_keys - actual_keys)
+            extra = sorted(actual_keys - required_keys)
+            lines = ["default_settings.json keys must match tagManager.yml settings exactly."]
+            if missing:
+                lines.append(f"  Missing keys (add to default_settings.json): {missing}")
+            if extra:
+                lines.append(f"  Extra keys (remove or add to tagManager.yml): {extra}")
+            lines.append(f"  Expected ({len(required_keys)}): {sorted(required_keys)}")
+            lines.append(f"  Actual   ({len(actual_keys)}): {sorted(actual_keys)}")
+            self.fail("\n".join(lines))
+
+        expected_python_type_by_setting_type = {
+            "BOOLEAN": bool,
+            "NUMBER": int,
+            "STRING": str,
+        }
+
+        type_errors = []
+        for key, setting_type in settings_schema.items():
+            if setting_type not in expected_python_type_by_setting_type:
+                type_errors.append(
+                    f"  {key}: unknown type {setting_type!r} in tagManager.yml "
+                    f"(expected BOOLEAN, NUMBER, or STRING)"
+                )
+                continue
+            expected_py = expected_python_type_by_setting_type[setting_type]
+            value = defaults[key]
+            if not isinstance(value, expected_py):
+                type_errors.append(
+                    f"  {key}: expected {setting_type} ({expected_py.__name__}), "
+                    f"got {type(value).__name__} ({value!r})"
+                )
+
+        if type_errors:
+            self.fail(
+                "default_settings.json value types do not match tagManager.yml:\n"
+                + "\n".join(type_errors)
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Loads all settings into stash on startup, so that the plugin settings page displays the correct setting (e.g. 80 for `fuzzyThreshold` instead of 0)

Introduce functions to merge new settings with existing settings; fixes saving certain settings (loading parent tags) deletes all settings.

==> Fixes https://github.com/carrotwaxr/stash-plugins/issues/123

Introduce `default_settings.json` as the single source of truth for user settings. This removes duplications and possible mismatches between `tag-manager.js` and `tag_manager.py`.

Add test `test_default_settings_file.py` to keep `default_settings.json` in lockstep with tagManager.yml.

### Further recommendations:

1)

It might now be possible to remove all additional settings fallbacks in the code and rely completely on the returns of the stash settings to reduce complexity:
```python
# Example
config.get("enableFuzzySearch")
    # instead of
config.get("enableFuzzySearch", DEFAULT_PLUGIN_SETTINGS["enableFuzzySearch"])
```

2)

Assuming scripts are only ever going to be called from `tag-manager.js`, it would be safe to integrate all default settings into `tag-manager.js` as Single Source of Truth (SSOT) instead of the external `default_settings.json`. The settings can then be propagated from `tag-manager.js` to python / elsewhere, which would remove complexity and fallback handling in these later scripts.

Let me know if this is something you want and I will look into it.