### PR TITLE
mcMetadata: processing conditions + fix #127 (v1.5.0)

### DIFF
--- a/docs/plans/2026-06-19-mcmetadata-processing-conditions-design.md
+++ b/docs/plans/2026-06-19-mcmetadata-processing-conditions-design.md
@@ -1,0 +1,198 @@
+# mcMetadata — Unified Processing Conditions (design)
+
+> **Status:** 🟢 ready (scoped, design validated 2026-06-19)
+> **Repo:** stash-plugins · **Plugin:** mcMetadata (v1.4.0)
+> **Theme:** ROADMAP P1 "mcMetadata processing conditions" (Theme B in `docs/CATCHUP-2026-06.md`)
+> **Closes / addresses:** GitHub #127 · Discourse #11, #13, #16, #18
+
+## Problem
+
+mcMetadata decides *whether* to touch a scene with logic that is **scattered and
+inconsistent between its two entry points**:
+
+- **Hook** (`Scene.Update.Post`, `mcMetadata.py:173-208`): three separate checks —
+  `requireStashId` (configurable, default off), `hookTriggerMode` (`always`/`on_organized`),
+  and a hardcoded cascade guard that skips already-organized scenes so the renamer's
+  mark-organized step doesn't re-fire the hook forever.
+- **Bulk task** (`process_all_scenes`, `scene.py:19-64`): hardcodes
+  `stash_id NOT_NULL` and **ignores every hook setting** — so it silently skips every
+  scene without a StashID. This is exactly GitHub **#127**.
+
+The community's dominant request for this plugin (8 Discourse posts) is finer, *consistent*
+control over when a scene is processed:
+
+- **#11** — process only when a scene is marked **Organized**.
+- **#18** — restrict by **required tag** or **directory** so a file is only processed once,
+  in its final location.
+- **#13 / #16** — the existing `hookTriggerMode` shipped but users couldn't find or
+  understand it (discoverability gap).
+- Proactive ask: a way to **see what would change before it runs**, to pre-empt the
+  "it processed files I didn't want" class of report.
+
+## Goals
+
+1. One **unified processing gate** used identically by the hook and the bulk task.
+2. Support four independently-optional conditions: **organized**, **required tags**,
+   **directory scope**, **StashID**.
+3. Fix **#127** as a natural consequence (bulk stops hardcoding the StashID filter).
+4. Make the existing `dryRun` answer "*which* scenes are skipped and *why*."
+5. Improve discoverability (settings descriptions, README, startup log).
+
+## Non-goals (YAGNI)
+
+- No tag-**hierarchy/descendant** resolution in v1 — exact tags only.
+- No **boolean-OR** logic between gates. #18's "required tag *or* directory" means two
+  *alternative restrictions*; each gate is independently optional and they AND together.
+- No new "preview-only" task — the enriched bulk dry-run covers it.
+- No per-condition `dryRun` override — the global flag is enough.
+- No ALL-match tag mode — ANY-match only (revisit if requested).
+
+## Design
+
+### The condition model — single source of truth
+
+A pure function evaluated by **both** paths:
+
+```python
+def should_process(scene, settings) -> tuple[bool, str]:
+    """Return (passes, reason). reason is "" on pass, else a short skip key."""
+```
+
+Gates, **combined with AND**; an unset gate is a no-op (never blocks):
+
+| Gate | Setting | Semantics | Skip-reason key |
+|------|---------|-----------|-----------------|
+| **Organized** | `organizedCondition`: `require`/`skip`/`ignore` | `require`→must be Organized (#11); `skip`→must *not* be; `ignore`→default | `not_organized` / `is_organized` |
+| **Required tags** | `requiredTags`: comma-sep tag names | Pass if scene has **any** listed tag (ANY-match). Empty → no-op | `missing_required_tag` |
+| **Directory scope** | `includePaths` / `excludePaths`: comma-sep globs | Pass if ≥1 file matches an include glob **and** no file matches an exclude. Empty include → all included; exclude wins | `outside_include_paths` / `excluded_path` |
+| **StashID** | `requireStashId`: bool (existing) | `true`→must have a StashID; honored by **bulk too** (fixes #127) | `no_stash_id` |
+
+Matching details:
+- **Tags**: exact tag-name match, ANY-of. No descendants in v1.
+- **Paths**: `fnmatch`-style globs, **case-insensitive**, matched against each file's
+  full path. Include = whitelist; exclude beats include. Multi-file scenes pass if any
+  file qualifies (consistent with `renamerMultiFileMode`'s per-file handling downstream).
+
+### Settings
+
+New / changed keys in `mcMetadata.yml` + `get_settings()` (`mcMetadata.py:67-110`):
+
+| Key | Type | Default | Notes |
+|-----|------|---------|-------|
+| `organizedCondition` | STRING | `ignore` | Replaces `hookTriggerMode` |
+| `requiredTags` | STRING | `""` | Comma-separated tag names |
+| `includePaths` | STRING | `""` | Comma-separated globs; empty = all |
+| `excludePaths` | STRING | `""` | Comma-separated globs |
+| `requireStashId` | BOOLEAN | `false` | Existing; now applied in bulk |
+| `dryRun` | BOOLEAN | `true` | Existing; enriched output (below) |
+
+**Deprecated:** `hookTriggerMode` (STRING) — still read when `organizedCondition` is unset,
+mapped `on_organized → require`, `always → ignore`. New key wins if both are set. Kept in
+the YAML one release for back-compat, with a description noting it's superseded.
+
+### Hook wiring
+
+Replace the three scattered checks at `mcMetadata.py:185-205` with one call:
+
+```python
+scene = stash.find_scene(scene_id)
+ok, reason = should_process(scene, SETTINGS)
+if not ok:
+    log.debug(f"Scene {scene_id} skipped: {reason}")
+    return
+process_scene(scene, stash, SETTINGS, api_key)
+```
+
+The old cascade guard is **subsumed**: a user wanting organized-only sets
+`organizedCondition=require` (re-fires are prevented in practice by
+`renamerIgnoreFilesInPath` + `nfoSkipExisting`); `skip` naturally avoids reprocessing
+organized scenes. No special-case code remains.
+
+### Bulk wiring + #127 fix
+
+`process_all_scenes` (`scene.py:19-64`) stops hardcoding `QUERY_WHERE_STASH_ID_NOT_NULL`:
+
+```python
+f = build_scene_filter(settings)          # server-side PREFILTER (optimization only)
+for scene in paginate(stash.find_scenes(f=f, ...)):
+    ok, reason = should_process(scene, settings)   # authoritative
+    if ok:
+        process_scene(scene, ...)
+    else:
+        skip_counts[reason] += 1
+```
+
+- **`should_process` is authoritative.** `build_scene_filter` only pushes the trivially
+  server-equivalent gates — **organized** (`organized: true/false`) and **StashID**
+  (`stash_id_endpoint NOT_NULL`) — to avoid fetching the whole library. It **must always
+  return a superset** of what `should_process` accepts. Tags and directory globs stay
+  client-side (tags could be pushed later once name→ID resolution exists; globs never can).
+- With `requireStashId` defaulting to **false**, null-StashID scenes are now processed →
+  **#127 resolved**.
+
+### Dry-run preview & skip reasons
+
+`should_process` already returns a reason; bulk tallies them and logs a histogram + a
+small sample at the end of every run (dry or live, at INFO):
+
+```
+[DRY RUN] Bulk scan: 1,240 scenes
+  → would process: 312
+  → skipped: 928
+      not_organized .......... 700
+      missing_required_tag ... 180
+      outside_include_paths .. 48
+  Sample skipped (first 10): [41] not_organized · [88] missing_required_tag 'curated' · …
+```
+
+### Discoverability (#13/#16)
+
+- `mcMetadata.yml` descriptions for the new keys carry concrete example values.
+- README gains a **"Processing conditions"** section: the 4-gate table + a worked example
+  ("only NFO my Organized, StashDB-linked scenes under `/media/curated`").
+- A one-line **startup INFO log** echoes the active gates so users can confirm config:
+  `Active conditions: organized=require, tags=[curated], include=[/media/curated/*]`.
+
+## Backwards compatibility
+
+- All new gates default to no-op → existing installs behave identically.
+- `hookTriggerMode` users are auto-migrated by the shim; no reconfiguration needed.
+- Additive + back-compat → **minor version bump (1.4.0 → 1.5.0)**.
+
+## Testing strategy
+
+Repo uses `pytest` (`plugins/mcMetadata/tests/`). New/updated tests:
+
+1. **`should_process` unit table** — per gate and in combination: organized 3-state;
+   tag ANY-match (present/absent/multiple); include/exclude globs (case, multi-file,
+   exclude-beats-include); `requireStashId`; AND-combination; every gate empty = pass.
+2. **Migration** — `hookTriggerMode=on_organized → require`, `always → ignore`, and that
+   `organizedCondition` overrides a stale `hookTriggerMode`.
+3. **Superset invariant** — over a fixture set of scenes, assert
+   `{passes build_scene_filter} ⊇ {passes should_process}` so the prefilter can never
+   silently drop a scene the gate would accept.
+4. **#127 regression** — a null-StashID scene is processed by bulk when
+   `requireStashId=false`, and skipped (reason `no_stash_id`) when `true`.
+5. **Dry-run histogram** — skip reasons are tallied correctly and totals reconcile
+   (`processed + skipped == scanned`).
+6. Existing mcMetadata tests stay green.
+
+## Rollout
+
+1. Branch/worktree under `.worktrees/` (per `CLAUDE.md`); TDD per the test plan above.
+2. Deploy to **stash-test** (`10.0.0.4:6971`) via rsync, reload, run the manual matrix:
+   hook `organized=require`; bulk with `includePaths`; dry-run histogram sanity.
+3. README "Processing conditions" section + YAML example values.
+4. Version bump → **1.5.0**; merge to `main`.
+5. **Republish the source index** (`build_site.sh`) so users actually receive it; deploy
+   to prod Stash (`6969`) after test passes.
+6. Close **#127** with a note; reply on Discourse **#11/#13/#18** pointing at the new
+   settings + the worked README example.
+
+## Open questions / future work
+
+- Push `requiredTags` into the server prefilter (needs tag name→ID resolution + ANY = `INCLUDES`).
+- Tag **descendant** matching (depth) if users ask for hierarchical tags.
+- Optional ALL-match tag mode.
+- A standalone "what would be processed" report task, only if the dry-run histogram proves
+  insufficient.

--- a/plugins/mcMetadata/README.md
+++ b/plugins/mcMetadata/README.md
@@ -1,6 +1,6 @@
 # mcMetadata Plugin for [Stash](https://github.com/stashapp/stash)
 
-**Version**: 1.4.0
+**Version**: 1.5.0
 
 This plugin is for users who manage their collection with Stash but serve content via Jellyfin, Emby, or Plex. Instead of relying on those media servers' scrapers, mcMetadata leverages your Stash database to generate `.nfo` metadata files and performer images that your media server can use.
 
@@ -36,8 +36,48 @@ All settings are configured through Stash's UI at **Settings → Plugins → mcM
 |---------|------|---------|-------------|
 | **Dry Run Mode** | Boolean | On | Preview changes without making them. Check logs to see what would happen. |
 | **Enable Scene Update Hook** | Boolean | Off | Automatically process scenes when you update them. |
-| **Require StashDB Link (Hook Only)** | Boolean | Off | Only process scenes linked to StashDB when using the hook. Enable this if you only want NFOs generated for curated StashDB content. |
-| **Hook Trigger Mode** | String | `always` | When to process scenes via hook: `always` (every save) or `on_organized` (only when scene is marked Organized). Useful if you make incremental edits and want to trigger metadata generation only when you're done. |
+
+### Processing Conditions
+
+Conditions control **which scenes get processed**. They apply identically to both the
+hook and the **Bulk Update Scenes** task. Each condition is independently optional — an
+unset condition never blocks — and all configured conditions must pass (AND).
+
+| Setting | Type | Default | Description |
+|---------|------|---------|-------------|
+| **Organized Condition** | String | `ignore` | `require` = only Organized scenes · `skip` = only NOT-yet-organized scenes · `ignore` = process either. Supersedes the old Hook Trigger Mode. |
+| **Require StashDB Link** | Boolean | Off | Only process scenes linked to StashDB. (Applies to bulk too — when off, scenes without a StashID are processed.) |
+| **Required Tags** | String | - | Comma-separated tag names; a scene is processed only if it has **at least one**. Example: `Curated, For Jellyfin` |
+| **Include Paths** | String | - | Comma-separated path globs; a scene is processed only if a file matches one. Example: `/media/curated/*` |
+| **Exclude Paths** | String | - | Comma-separated path globs; a scene is skipped if a file matches one. **Exclude wins over Include.** Example: `*/trash/*` |
+
+Path globs are case-insensitive and `*` spans directory separators, so `/media/curated/*`
+also matches files in its subfolders.
+
+**Worked example** — only generate NFOs for your Organized, StashDB-linked scenes under
+`/media/curated`:
+
+- Organized Condition = `require`
+- Require StashDB Link = `On`
+- Include Paths = `/media/curated/*`
+
+When you run **Bulk Update Scenes** in Dry Run, the log ends with a histogram of how many
+scenes were skipped and why, plus a sample — so you can confirm your conditions before a
+live run:
+
+```
+[DRY RUN] Bulk scan complete: 1240 scanned
+  -> processed: 312
+  -> skipped: 928
+      not_organized........... 700
+      missing_required_tag.... 180
+      outside_include_paths... 48
+  sample skipped: [41] not_organized | [88] missing_required_tag
+```
+
+> **Migrating from Hook Trigger Mode?** It's deprecated but still honored when Organized
+> Condition is left unset: `on_organized` → `require`, `always` → `ignore`. Set Organized
+> Condition to take over.
 
 ### File Renamer Settings
 
@@ -106,7 +146,7 @@ If a block contains multiple variables, ALL must have values for the block to ap
 
 1. Go to **Settings → Tasks → Plugin Tasks**
 2. Select:
-   - **Bulk Update Scenes**: Process all scenes with StashIDs
+   - **Bulk Update Scenes**: Process all scenes (subject to your Processing Conditions)
    - **Bulk Update Performers**: Copy all performer images to media server
 
 ### Using the Hook
@@ -158,6 +198,12 @@ Common issues:
 - `stashapp-tools>=0.2.59` (installed automatically)
 
 ## Changelog
+
+### v1.5.0
+- **Unified Processing Conditions** applied to both the hook and the bulk task: Organized Condition (`require`/`skip`/`ignore`), Required Tags, and Include/Exclude path globs, alongside the existing Require StashDB Link
+- **Fixed #127**: the bulk task no longer silently skips scenes without a StashID — it now processes all scenes (subject to your conditions)
+- Bulk Dry Run now prints a skip-reason histogram + sample, so you can preview what would be processed before a live run
+- `hookTriggerMode` is deprecated in favor of Organized Condition (auto-migrated when Organized Condition is unset: `on_organized` → require, `always` → ignore)
 
 ### v1.4.0
 - Added `hookTriggerMode` setting: choose to process scenes on every save (`always`) or only when marked Organized (`on_organized`) (#111)

--- a/plugins/mcMetadata/conditions.py
+++ b/plugins/mcMetadata/conditions.py
@@ -1,0 +1,132 @@
+"""Unified processing-conditions gate for mcMetadata.
+
+`should_process` is the single source of truth for whether a scene gets processed,
+used identically by the hook and the bulk task. It is a pure function with no Stash
+dependency so it is trivial to test and reason about.
+
+Gates (all independently optional, AND-combined; an unset gate never blocks):
+  - organized:     organized_condition = require | skip | ignore
+  - StashID:       require_stash_id (bool)
+  - required tags: required_tags (list of names, ANY-match)
+  - directory:     include_paths / exclude_paths (lists of globs; exclude wins)
+
+Returns (passes, reason). reason is "" on pass, else a short skip key suitable for
+the bulk dry-run histogram: not_organized | is_organized | no_stash_id |
+missing_required_tag | excluded_path | outside_include_paths.
+"""
+
+from fnmatch import fnmatchcase
+
+
+def _matches_any(path, patterns):
+    """Case-insensitive fnmatch of a file path against any of the glob patterns."""
+    p = path.lower()
+    return any(fnmatchcase(p, pat.lower()) for pat in patterns)
+
+
+def build_scene_filter(settings):
+    """Server-side prefilter for the bulk task — an OPTIMIZATION, never authoritative.
+
+    Pushes only the gates Stash can express identically (organized, StashID) into
+    find_scenes so the whole library isn't fetched. It MUST stay a superset of what
+    should_process accepts: tags and directory globs are deliberately NOT pushed (they
+    are evaluated client-side), so the returned filter can never drop a scene the gate
+    would have processed. should_process remains the source of truth.
+    """
+    f = {}
+    organized_condition = settings.get("organized_condition", "ignore")
+    if organized_condition == "require":
+        f["organized"] = True
+    elif organized_condition == "skip":
+        f["organized"] = False
+    if settings.get("require_stash_id", False):
+        f["stash_id_endpoint"] = {"endpoint": "", "modifier": "NOT_NULL", "stash_id": ""}
+    return f
+
+
+def describe_active_conditions(settings):
+    """One-line summary of the active gates, for a startup log (#13 discoverability)."""
+    parts = []
+    organized_condition = settings.get("organized_condition", "ignore")
+    if organized_condition in ("require", "skip"):
+        parts.append(f"organized={organized_condition}")
+    if settings.get("require_stash_id", False):
+        parts.append("stashID=required")
+    required_tags = settings.get("required_tags") or []
+    if required_tags:
+        parts.append(f"tags=[{', '.join(required_tags)}]")
+    include_paths = settings.get("include_paths") or []
+    if include_paths:
+        parts.append(f"include=[{', '.join(include_paths)}]")
+    exclude_paths = settings.get("exclude_paths") or []
+    if exclude_paths:
+        parts.append(f"exclude=[{', '.join(exclude_paths)}]")
+
+    if not parts:
+        return "Active conditions: none (processing all scenes)"
+    return "Active conditions: " + ", ".join(parts)
+
+
+def format_bulk_summary(summary, dry_run=False):
+    """Render a bulk-run summary into log lines: totals + a skip-reason histogram.
+
+    This answers "which scenes were skipped, and why" for the dry-run preview, so users
+    can confirm their conditions before a live run. Returns a list of strings to log.
+    """
+    prefix = "[DRY RUN] " if dry_run else ""
+    scanned = summary.get("scanned", 0)
+    processed = summary.get("processed", 0)
+    errors = summary.get("errors", 0)
+    skipped = summary.get("skipped", {}) or {}
+    total_skipped = sum(skipped.values())
+
+    lines = [
+        f"{prefix}Bulk scan complete: {scanned} scanned",
+        f"  -> processed: {processed}",
+        f"  -> skipped: {total_skipped}",
+    ]
+    # Histogram, most common reason first (ties broken alphabetically for stability).
+    for reason, n in sorted(skipped.items(), key=lambda kv: (-kv[1], kv[0])):
+        lines.append(f"      {reason.ljust(24, '.')} {n}")
+    if errors:
+        lines.append(f"  -> errors: {errors}")
+
+    samples = summary.get("samples") or []
+    if samples:
+        rendered = " | ".join(f"[{sid}] {reason}" for sid, reason in samples)
+        lines.append(f"  sample skipped: {rendered}")
+    return lines
+
+
+def should_process(scene, settings):
+    """Evaluate the processing gates for a scene. Returns (bool, reason_str)."""
+    # --- organized -------------------------------------------------------
+    organized_condition = settings.get("organized_condition", "ignore")
+    organized = bool(scene.get("organized", False))
+    if organized_condition == "require" and not organized:
+        return (False, "not_organized")
+    if organized_condition == "skip" and organized:
+        return (False, "is_organized")
+
+    # --- StashID ---------------------------------------------------------
+    if settings.get("require_stash_id", False) and not scene.get("stash_ids"):
+        return (False, "no_stash_id")
+
+    # --- required tags (ANY-match) ---------------------------------------
+    required_tags = settings.get("required_tags") or []
+    if required_tags:
+        scene_tags = {t.get("name", "") for t in (scene.get("tags") or [])}
+        if not scene_tags.intersection(required_tags):
+            return (False, "missing_required_tag")
+
+    # --- directory scope (exclude beats include) -------------------------
+    include_paths = settings.get("include_paths") or []
+    exclude_paths = settings.get("exclude_paths") or []
+    if include_paths or exclude_paths:
+        paths = [f.get("path", "") for f in (scene.get("files") or [])]
+        if exclude_paths and any(_matches_any(p, exclude_paths) for p in paths):
+            return (False, "excluded_path")
+        if include_paths and not any(_matches_any(p, include_paths) for p in paths):
+            return (False, "outside_include_paths")
+
+    return (True, "")

--- a/plugins/mcMetadata/mcMetadata.py
+++ b/plugins/mcMetadata/mcMetadata.py
@@ -128,9 +128,6 @@ def main():
         if SETTINGS["dry_run"]:
             log.info("[DRY RUN] Mode enabled - no changes will be made")
 
-        # Echo the active processing conditions so users can confirm their config
-        log.info(describe_active_conditions(SETTINGS))
-
         # Get API key for modes that need it
         try:
             stash_config = stash.get_configuration()["general"]
@@ -142,6 +139,7 @@ def main():
         # Handle processing modes
         if mode == "bulk":
             log.info("Starting bulk scene update")
+            log.info(describe_active_conditions(SETTINGS))
             process_all_scenes(stash, SETTINGS, api_key)
             log.info("Bulk scene update completed")
 

--- a/plugins/mcMetadata/mcMetadata.py
+++ b/plugins/mcMetadata/mcMetadata.py
@@ -4,7 +4,7 @@ mcMetadata - Stash Plugin for Media Center Metadata Generation
 Generates NFO files for Jellyfin/Emby, organizes video files according to
 configurable templates, and exports performer images to media server folders.
 
-Version: 1.4.0
+Version: 1.5.0
 """
 
 import json
@@ -14,6 +14,8 @@ from utils.logger import init_file_logger, close_file_logger
 import utils.logger as log
 from performer import process_all_performers
 from scene import process_all_scenes, process_scene
+from conditions import should_process, describe_active_conditions
+from plugin_settings import map_settings
 
 # Minimum stashapp-tools version required for schema 72+ compatibility
 MIN_STASHAPP_TOOLS_VERSION = "0.2.59"
@@ -68,7 +70,9 @@ def get_settings(stash_instance):
     """Load settings from Stash's plugin configuration.
 
     Stash stores plugin settings in its database and provides them
-    via the configuration endpoint. This replaces the old ini file approach.
+    via the configuration endpoint. The camelCase -> snake_case mapping
+    (with defaults, list-parsing, and the hookTriggerMode migration) lives
+    in plugin_settings.map_settings so it can be unit-tested independently.
 
     Returns:
         dict: Settings dictionary with snake_case keys for internal use
@@ -80,34 +84,7 @@ def get_settings(stash_instance):
         log.error(f"Failed to get plugin configuration: {err}")
         plugin_config = {}
 
-    # Map from Stash camelCase settings to internal snake_case
-    # with sensible defaults
-    return {
-        "dry_run": plugin_config.get("dryRun", True),  # Default to safe mode
-        "log_file_path": plugin_config.get("logFilePath", ""),  # Optional file logging
-        "enable_hook": plugin_config.get("enableHook", False),  # Default off for safety
-        "require_stash_id": plugin_config.get("requireStashId", False),  # Default off - process all scenes
-        "hook_trigger_mode": plugin_config.get("hookTriggerMode", "always"),
-        "enable_renamer": plugin_config.get("enableRenamer", False),
-        "renamer_path": plugin_config.get("renamerPath", ""),
-        "renamer_path_template": plugin_config.get(
-            "renamerPathTemplate",
-            "$Studio/$Title - $Performers $ReleaseDate [$Resolution]"
-        ),
-        "renamer_filepath_budget": plugin_config.get("renamerFilepathBudget", 250),
-        "renamer_ignore_files_in_path": plugin_config.get("renamerIgnoreFilesInPath", False),
-        "renamer_enable_mark_organized": plugin_config.get("renamerMarkOrganized", True),
-        "renamer_multi_file_mode": plugin_config.get("renamerMultiFileMode", "all"),
-        "nfo_skip_existing": plugin_config.get("nfoSkipExisting", False),
-        "nfo_exclude_fields": [
-            f.strip().lower()
-            for f in plugin_config.get("nfoExcludeFields", "").split(",")
-            if f.strip()
-        ],
-        "enable_actor_images": plugin_config.get("enableActorImages", False),
-        "media_server": plugin_config.get("mediaServer", "jellyfin"),
-        "actor_metadata_path": plugin_config.get("actorMetadataPath", ""),
-    }
+    return map_settings(plugin_config)
 
 
 # Load settings from Stash
@@ -151,6 +128,9 @@ def main():
         if SETTINGS["dry_run"]:
             log.info("[DRY RUN] Mode enabled - no changes will be made")
 
+        # Echo the active processing conditions so users can confirm their config
+        log.info(describe_active_conditions(SETTINGS))
+
         # Get API key for modes that need it
         try:
             stash_config = stash.get_configuration()["general"]
@@ -182,27 +162,14 @@ def main():
                 log.warning(f"Scene {scene_id} not found")
                 return
 
-            # Check if we require StashDB link (configurable, default OFF)
-            require_stash_id = SETTINGS.get("require_stash_id", False)
-            stash_ids = scene.get("stash_ids", [])
-
-            if require_stash_id and not stash_ids:
-                log.debug(f"Scene {scene_id} has no StashID, skipping (requireStashId is enabled)")
+            # Unified processing-conditions gate (organized / required tags /
+            # directory scope / StashID). This subsumes the old hookTriggerMode
+            # and the cascade guard: organizedCondition=require gives organized-only
+            # processing; organizedCondition=skip avoids reprocessing organized scenes.
+            ok, reason = should_process(scene, SETTINGS)
+            if not ok:
+                log.debug(f"Scene {scene_id} skipped by processing conditions: {reason}")
                 return
-
-            # Check hook trigger mode (#111)
-            hook_trigger_mode = SETTINGS.get("hook_trigger_mode", "always")
-            if hook_trigger_mode == "on_organized" and not scene.get("organized", False):
-                log.debug(f"Scene {scene_id} not organized, skipping (hookTriggerMode=on_organized)")
-                return
-
-            # Cascade protection: skip already-organized scenes to prevent re-firing
-            # after the plugin marks a scene as organized during rename.
-            # Skip this check in on_organized mode — user explicitly wants organized triggers.
-            if hook_trigger_mode != "on_organized":
-                if SETTINGS.get("renamer_enable_mark_organized", False) and scene.get("organized", False):
-                    log.debug(f"Scene {scene_id} already organized, skipping to prevent hook cascade")
-                    return
 
             log.info(f"Processing scene {scene_id}")
             process_scene(scene, stash, SETTINGS, api_key)

--- a/plugins/mcMetadata/mcMetadata.yml
+++ b/plugins/mcMetadata/mcMetadata.yml
@@ -1,7 +1,7 @@
 name: mcMetadata
 description: Generates NFO metadata files for Jellyfin/Emby/Plex, organizes/renames video files using customizable templates, and exports performer images to media server folders.
 url: https://github.com/carrotwaxr/stash-plugins/tree/main/plugins/mcMetadata
-version: 1.4.0
+version: 1.5.0
 exec:
   - python
   - "{pluginDir}/mcMetadata.py"
@@ -22,12 +22,28 @@ settings:
     description: Process scenes automatically when you update them. Disable to only use bulk tasks. Default is OFF.
     type: BOOLEAN
   requireStashId:
-    displayName: Require StashDB Link (Hook Only)
-    description: Only process scenes that are linked to StashDB when using the hook. Enable this to only generate NFOs for curated StashDB content. Default is OFF.
+    displayName: Require StashDB Link
+    description: "Processing condition: only process scenes linked to StashDB. Applies to both the hook and the bulk task. Use to generate NFOs only for curated StashDB content. Default is OFF (process all scenes)."
     type: BOOLEAN
+  organizedCondition:
+    displayName: Organized Condition
+    description: "Processing condition: 'require' (only Organized scenes), 'skip' (only NOT-yet-organized scenes), or 'ignore' (process either). Applies to the hook and bulk task. Default is 'ignore'. Supersedes Hook Trigger Mode."
+    type: STRING
+  requiredTags:
+    displayName: Required Tags
+    description: "Processing condition: comma-separated tag names; a scene is processed only if it has at least one. Example: Curated, For Jellyfin. Leave empty to process scenes with any tags."
+    type: STRING
+  includePaths:
+    displayName: Include Paths
+    description: "Processing condition: comma-separated path globs; a scene is processed only if a file matches one. Example: /media/curated/*. Leave empty to include all locations."
+    type: STRING
+  excludePaths:
+    displayName: Exclude Paths
+    description: "Processing condition: comma-separated path globs; a scene is skipped if a file matches one. Exclude wins over Include. Example: */trash/*, /media/staging/*. Leave empty to exclude nothing."
+    type: STRING
   hookTriggerMode:
-    displayName: Hook Trigger Mode
-    description: "When to process scenes via hook: 'always' (every save) or 'on_organized' (only when scene is marked Organized). Default is 'always'."
+    displayName: Hook Trigger Mode (deprecated)
+    description: "DEPRECATED — use Organized Condition instead. Still honored for back-compat when Organized Condition is unset: 'on_organized' maps to require, 'always' maps to ignore."
     type: STRING
   enableRenamer:
     displayName: Enable File Renamer

--- a/plugins/mcMetadata/plugin_settings.py
+++ b/plugins/mcMetadata/plugin_settings.py
@@ -1,0 +1,64 @@
+"""Pure mapping from Stash's camelCase plugin config to internal snake_case settings.
+
+Kept separate from mcMetadata.py (which reads stdin at import) so the mapping —
+including list-parsing and the hookTriggerMode -> organizedCondition migration — is
+unit-testable without a Stash connection.
+"""
+
+_VALID_ORGANIZED = ("require", "skip", "ignore")
+
+
+def _split_csv(value):
+    """Comma-separated string -> trimmed list, empties dropped."""
+    return [s.strip() for s in (value or "").split(",") if s.strip()]
+
+
+def _resolve_organized_condition(plugin_config):
+    """organizedCondition if valid, else migrate the legacy hookTriggerMode.
+
+    on_organized -> require; always/empty/unknown -> ignore. The new key wins.
+    """
+    raw = (plugin_config.get("organizedCondition") or "").strip().lower()
+    if raw in _VALID_ORGANIZED:
+        return raw
+    legacy = (plugin_config.get("hookTriggerMode") or "").strip().lower()
+    if legacy == "on_organized":
+        return "require"
+    return "ignore"
+
+
+def map_settings(plugin_config):
+    """Map a Stash plugin config dict to the internal settings dict (with defaults)."""
+    return {
+        "dry_run": plugin_config.get("dryRun", True),  # Default to safe mode
+        "log_file_path": plugin_config.get("logFilePath", ""),  # Optional file logging
+        "enable_hook": plugin_config.get("enableHook", False),  # Default off for safety
+        # Processing conditions (unified gate)
+        "organized_condition": _resolve_organized_condition(plugin_config),
+        "require_stash_id": plugin_config.get("requireStashId", False),  # Default off - process all scenes (#127)
+        "required_tags": _split_csv(plugin_config.get("requiredTags", "")),
+        "include_paths": _split_csv(plugin_config.get("includePaths", "")),
+        "exclude_paths": _split_csv(plugin_config.get("excludePaths", "")),
+        # Renamer
+        "enable_renamer": plugin_config.get("enableRenamer", False),
+        "renamer_path": plugin_config.get("renamerPath", ""),
+        "renamer_path_template": plugin_config.get(
+            "renamerPathTemplate",
+            "$Studio/$Title - $Performers $ReleaseDate [$Resolution]"
+        ),
+        "renamer_filepath_budget": plugin_config.get("renamerFilepathBudget", 250),
+        "renamer_ignore_files_in_path": plugin_config.get("renamerIgnoreFilesInPath", False),
+        "renamer_enable_mark_organized": plugin_config.get("renamerMarkOrganized", True),
+        "renamer_multi_file_mode": plugin_config.get("renamerMultiFileMode", "all"),
+        # NFO
+        "nfo_skip_existing": plugin_config.get("nfoSkipExisting", False),
+        "nfo_exclude_fields": [
+            f.strip().lower()
+            for f in plugin_config.get("nfoExcludeFields", "").split(",")
+            if f.strip()
+        ],
+        # Actor images
+        "enable_actor_images": plugin_config.get("enableActorImages", False),
+        "media_server": plugin_config.get("mediaServer", "jellyfin"),
+        "actor_metadata_path": plugin_config.get("actorMetadataPath", ""),
+    }

--- a/plugins/mcMetadata/scene.py
+++ b/plugins/mcMetadata/scene.py
@@ -1,59 +1,78 @@
 import os
+from collections import Counter
 import utils.logger as log
 from performer import process_performer
 from utils.files import download_image, rename_file, replace_file_ext
 from utils.nfo import build_nfo_xml
 from utils.replacer import get_new_path
+from conditions import should_process, build_scene_filter, format_bulk_summary
+
+SKIP_SAMPLE_LIMIT = 10
 
 BATCH_SIZE = 100
 IMPOSSIBLE_PATH = "$%^&@"
-QUERY_WHERE_STASH_ID_NOT_NULL = {
-    "stash_id_endpoint": {
-        "endpoint": "",
-        "modifier": "NOT_NULL",
-        "stash_id": "",
-    }
-}
 
 
 def process_all_scenes(stash, settings, api_key):
-    """Process all scenes that have a StashID.
+    """Process scenes in bulk, gated by the unified processing conditions.
+
+    build_scene_filter narrows the server-side fetch where Stash can express a gate
+    exactly (organized, StashID); should_process is the authoritative gate applied to
+    every fetched scene. Scenes the gate rejects are tallied by reason for the dry-run
+    histogram instead of being silently dropped (fixes #127 for null-StashID scenes).
 
     Args:
         stash: StashInterface instance
         settings: Plugin settings dict
         api_key: Stash API key for image URLs
+
+    Returns:
+        dict: {"scanned", "processed", "errors", "skipped": {reason: count}}
     """
+    scene_filter = build_scene_filter(settings)
     count = stash.find_scenes(
-        f=QUERY_WHERE_STASH_ID_NOT_NULL,
+        f=scene_filter,
         filter={"per_page": 1},
         get_count=True,
     )[0]
 
-    log.info(f"Found {count} scenes with StashIDs to process")
+    log.info(f"Found {count} candidate scenes to evaluate")
+
+    summary = {"scanned": 0, "processed": 0, "errors": 0, "skipped": {}}
+    skipped = Counter()
+    samples = []
 
     if count == 0:
         log.info("No scenes to process")
-        return
+        return summary
 
     # Calculate total pages (ceiling division)
     total_pages = (count + BATCH_SIZE - 1) // BATCH_SIZE
     processed = 0
     errors = 0
+    scanned = 0
 
     # Pages are 1-indexed in Stash API
     for page in range(1, total_pages + 1):
         start = (page - 1) * BATCH_SIZE + 1
         end = min(page * BATCH_SIZE, count)
 
-        log.info(f"Processing scenes {start}-{end} of {count} (page {page}/{total_pages})")
+        log.info(f"Evaluating scenes {start}-{end} of {count} (page {page}/{total_pages})")
 
         scenes = stash.find_scenes(
-            f=QUERY_WHERE_STASH_ID_NOT_NULL,
+            f=scene_filter,
             filter={"page": page, "per_page": BATCH_SIZE},
         )
 
         for scene in scenes:
+            scanned += 1
+            ok, reason = should_process(scene, settings)
+            if not ok:
+                skipped[reason] += 1
+                if len(samples) < SKIP_SAMPLE_LIMIT:
+                    samples.append((scene.get("id", "?"), reason))
+                log.debug(f"Scene {scene.get('id', '?')} skipped by processing conditions: {reason}")
+                continue
             try:
                 process_scene(scene, stash, settings, api_key)
                 processed += 1
@@ -61,7 +80,15 @@ def process_all_scenes(stash, settings, api_key):
                 errors += 1
                 log.error(f"Error processing scene {scene.get('id', 'unknown')}: {err}")
 
-    log.info(f"Bulk scene update complete. Processed: {processed}, Errors: {errors}")
+    summary["scanned"] = scanned
+    summary["processed"] = processed
+    summary["errors"] = errors
+    summary["skipped"] = dict(skipped)
+    summary["samples"] = samples
+
+    for line in format_bulk_summary(summary, dry_run=settings.get("dry_run", False)):
+        log.info(line)
+    return summary
 
 
 def process_scene(scene, stash, settings, api_key):

--- a/plugins/mcMetadata/tests/test_bulk.py
+++ b/plugins/mcMetadata/tests/test_bulk.py
@@ -1,0 +1,208 @@
+"""
+Unit tests for the bulk path: the server-side prefilter (build_scene_filter), the
+superset invariant that guarantees it never drops a scene the gate would accept, the
+#127 regression (null-StashID scenes processed), and the dry-run skip histogram.
+
+Run with: python -m pytest tests/test_bulk.py -v
+"""
+
+import itertools
+import os
+import sys
+import unittest
+from unittest.mock import MagicMock, patch
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+sys.modules["stashapi"] = MagicMock()
+sys.modules["stashapi.log"] = MagicMock()
+
+from conditions import should_process, build_scene_filter, format_bulk_summary
+
+
+def _settings(**overrides):
+    base = {
+        "organized_condition": "ignore",
+        "require_stash_id": False,
+        "required_tags": [],
+        "include_paths": [],
+        "exclude_paths": [],
+        "dry_run": True,
+    }
+    base.update(overrides)
+    return base
+
+
+class TestBuildSceneFilter(unittest.TestCase):
+    def test_default_is_empty(self):
+        self.assertEqual(build_scene_filter(_settings()), {})
+
+    def test_require_organized_pushes_true(self):
+        self.assertEqual(build_scene_filter(_settings(organized_condition="require")), {"organized": True})
+
+    def test_skip_organized_pushes_false(self):
+        self.assertEqual(build_scene_filter(_settings(organized_condition="skip")), {"organized": False})
+
+    def test_require_stash_id_pushes_not_null(self):
+        f = build_scene_filter(_settings(require_stash_id=True))
+        self.assertEqual(f["stash_id_endpoint"]["modifier"], "NOT_NULL")
+
+    def test_tags_and_paths_are_not_pushed_server_side(self):
+        f = build_scene_filter(_settings(required_tags=["curated"], include_paths=["/x/*"]))
+        self.assertNotIn("tags", f)
+        self.assertNotIn("path", f)
+        self.assertEqual(f, {})
+
+
+def _passes_server_filter(scene, f):
+    """Simulate how Stash applies the f-filter, mirroring build_scene_filter's fields."""
+    if "organized" in f and bool(scene.get("organized", False)) != f["organized"]:
+        return False
+    if "stash_id_endpoint" in f and not scene.get("stash_ids"):
+        return False
+    return True
+
+
+class TestSupersetInvariant(unittest.TestCase):
+    """The server prefilter must accept every scene the gate accepts (superset),
+    so the bulk task can never silently drop a scene should_process would process."""
+
+    def test_filter_is_superset_of_gate_over_matrix(self):
+        scenes = []
+        for organized, has_id, tag, path in itertools.product(
+            [True, False], [True, False], ["curated", "other"],
+            ["/media/curated/a.mp4", "/media/trash/a.mp4"],
+        ):
+            scenes.append({
+                "id": "x",
+                "organized": organized,
+                "stash_ids": [{"stash_id": "s"}] if has_id else [],
+                "tags": [{"name": tag}],
+                "files": [{"path": path}],
+            })
+
+        settings_matrix = [
+            _settings(),
+            _settings(organized_condition="require"),
+            _settings(organized_condition="skip"),
+            _settings(require_stash_id=True),
+            _settings(required_tags=["curated"]),
+            _settings(include_paths=["/media/curated/*"]),
+            _settings(exclude_paths=["/media/trash/*"]),
+            _settings(organized_condition="require", require_stash_id=True,
+                      required_tags=["curated"], include_paths=["/media/curated/*"]),
+        ]
+
+        for st in settings_matrix:
+            f = build_scene_filter(st)
+            for sc in scenes:
+                if should_process(sc, st)[0]:
+                    self.assertTrue(
+                        _passes_server_filter(sc, f),
+                        msg=f"gate accepted but server filter dropped: settings={st} scene={sc}",
+                    )
+
+
+class FakeStash:
+    """Minimal stash double: applies the server filter, paginates, counts."""
+
+    def __init__(self, scenes):
+        self.scenes = scenes
+
+    def _filtered(self, f):
+        return [s for s in self.scenes if _passes_server_filter(s, f or {})]
+
+    def find_scenes(self, f=None, filter=None, get_count=False):
+        matched = self._filtered(f)
+        if get_count:
+            return [len(matched)]
+        page = filter["page"]
+        per = filter["per_page"]
+        start = (page - 1) * per
+        return matched[start:start + per]
+
+
+class TestBulkProcessing(unittest.TestCase):
+    def _run(self, scenes, settings):
+        import scene as scene_module
+        with patch.object(scene_module, "process_scene") as spy:
+            summary = scene_module.process_all_scenes(FakeStash(scenes), settings, api_key="k")
+            return summary, spy
+
+    def test_null_stash_id_scene_is_processed_by_default(self):
+        # #127: bulk must process scenes without a StashID when the gate is off.
+        scenes = [{"id": "1", "organized": False, "stash_ids": [], "tags": [], "files": [{"path": "/m/a.mp4"}]}]
+        summary, spy = self._run(scenes, _settings())
+        self.assertEqual(spy.call_count, 1)
+        self.assertEqual(summary["processed"], 1)
+
+    def test_require_stash_id_skips_null_and_counts_reason(self):
+        scenes = [
+            {"id": "1", "organized": False, "stash_ids": [], "tags": [], "files": [{"path": "/m/a.mp4"}]},
+            {"id": "2", "organized": False, "stash_ids": [{"stash_id": "s"}], "tags": [], "files": [{"path": "/m/b.mp4"}]},
+        ]
+        summary, spy = self._run(scenes, _settings(require_stash_id=True))
+        # Scene 1 is dropped by the server prefilter (not even fetched); scene 2 processed.
+        self.assertEqual(spy.call_count, 1)
+        self.assertEqual(summary["processed"], 1)
+
+    def test_client_side_gate_skips_are_counted_in_histogram(self):
+        scenes = [
+            {"id": "1", "organized": False, "stash_ids": [], "tags": [{"name": "curated"}], "files": [{"path": "/m/a.mp4"}]},
+            {"id": "2", "organized": False, "stash_ids": [], "tags": [{"name": "other"}], "files": [{"path": "/m/b.mp4"}]},
+            {"id": "3", "organized": False, "stash_ids": [], "tags": [], "files": [{"path": "/m/c.mp4"}]},
+        ]
+        summary, spy = self._run(scenes, _settings(required_tags=["curated"]))
+        self.assertEqual(spy.call_count, 1)               # only scene 1 processed
+        self.assertEqual(summary["processed"], 1)
+        self.assertEqual(summary["skipped"]["missing_required_tag"], 2)
+
+    def test_summary_totals_reconcile(self):
+        scenes = [
+            {"id": str(i), "organized": False, "stash_ids": [], "tags": [{"name": "curated"}] if i % 2 else [], "files": [{"path": "/m/x.mp4"}]}
+            for i in range(5)
+        ]
+        summary, _ = self._run(scenes, _settings(required_tags=["curated"]))
+        self.assertEqual(summary["scanned"], 5)
+        self.assertEqual(summary["processed"] + sum(summary["skipped"].values()) + summary["errors"], 5)
+
+
+class TestFormatBulkSummary(unittest.TestCase):
+    def test_includes_totals(self):
+        text = "\n".join(format_bulk_summary(
+            {"scanned": 100, "processed": 40, "errors": 0,
+             "skipped": {"not_organized": 50, "missing_required_tag": 10}}))
+        self.assertIn("100", text)
+        self.assertIn("processed: 40", text)
+        self.assertIn("skipped: 60", text)
+        self.assertIn("not_organized", text)
+        self.assertIn("missing_required_tag", text)
+
+    def test_reasons_sorted_descending(self):
+        text = "\n".join(format_bulk_summary(
+            {"scanned": 75, "processed": 0, "errors": 0,
+             "skipped": {"no_stash_id": 5, "not_organized": 50, "excluded_path": 20}}))
+        self.assertLess(text.index("not_organized"), text.index("excluded_path"))
+        self.assertLess(text.index("excluded_path"), text.index("no_stash_id"))
+
+    def test_dry_run_prefix(self):
+        lines = format_bulk_summary(
+            {"scanned": 1, "processed": 1, "errors": 0, "skipped": {}}, dry_run=True)
+        self.assertTrue(any("DRY RUN" in line for line in lines))
+
+    def test_errors_shown_when_present(self):
+        text = "\n".join(format_bulk_summary(
+            {"scanned": 3, "processed": 1, "errors": 2, "skipped": {}}))
+        self.assertIn("errors: 2", text)
+
+    def test_samples_listed_when_present(self):
+        text = "\n".join(format_bulk_summary(
+            {"scanned": 3, "processed": 1, "errors": 0,
+             "skipped": {"not_organized": 2},
+             "samples": [("41", "not_organized"), ("88", "not_organized")]}))
+        self.assertIn("41", text)
+        self.assertIn("88", text)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/plugins/mcMetadata/tests/test_conditions.py
+++ b/plugins/mcMetadata/tests/test_conditions.py
@@ -1,0 +1,251 @@
+"""
+Unit tests for the unified processing-conditions gate (conditions.should_process).
+
+No Stash connection required. should_process is a pure function over a scene dict
+and a snake_case settings dict (lists already parsed from the comma-separated UI strings).
+
+Run with: python -m pytest tests/test_conditions.py -v
+"""
+
+import os
+import sys
+import unittest
+from unittest.mock import MagicMock
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+# Mock stashapi so importing plugin modules never needs the real package.
+sys.modules["stashapi"] = MagicMock()
+sys.modules["stashapi.log"] = MagicMock()
+
+from conditions import should_process, describe_active_conditions
+
+
+def scene(**overrides):
+    """A minimal scene dict; override any field."""
+    base = {
+        "id": "1",
+        "organized": False,
+        "stash_ids": [],
+        "tags": [],
+        "files": [{"path": "/media/library/scene.mp4"}],
+    }
+    base.update(overrides)
+    return base
+
+
+def settings(**overrides):
+    """Default settings = every gate a no-op."""
+    base = {
+        "organized_condition": "ignore",
+        "require_stash_id": False,
+        "required_tags": [],
+        "include_paths": [],
+        "exclude_paths": [],
+    }
+    base.update(overrides)
+    return base
+
+
+class TestNoConditions(unittest.TestCase):
+    def test_all_gates_unset_passes(self):
+        ok, reason = should_process(scene(), settings())
+        self.assertTrue(ok)
+        self.assertEqual(reason, "")
+
+
+class TestOrganizedGate(unittest.TestCase):
+    def test_require_passes_when_organized(self):
+        ok, _ = should_process(scene(organized=True), settings(organized_condition="require"))
+        self.assertTrue(ok)
+
+    def test_require_blocks_when_not_organized(self):
+        ok, reason = should_process(scene(organized=False), settings(organized_condition="require"))
+        self.assertFalse(ok)
+        self.assertEqual(reason, "not_organized")
+
+    def test_skip_blocks_when_organized(self):
+        ok, reason = should_process(scene(organized=True), settings(organized_condition="skip"))
+        self.assertFalse(ok)
+        self.assertEqual(reason, "is_organized")
+
+    def test_skip_passes_when_not_organized(self):
+        ok, _ = should_process(scene(organized=False), settings(organized_condition="skip"))
+        self.assertTrue(ok)
+
+    def test_ignore_passes_either_way(self):
+        self.assertTrue(should_process(scene(organized=True), settings(organized_condition="ignore"))[0])
+        self.assertTrue(should_process(scene(organized=False), settings(organized_condition="ignore"))[0])
+
+
+class TestStashIdGate(unittest.TestCase):
+    def test_require_blocks_when_missing(self):
+        ok, reason = should_process(scene(stash_ids=[]), settings(require_stash_id=True))
+        self.assertFalse(ok)
+        self.assertEqual(reason, "no_stash_id")
+
+    def test_require_passes_when_present(self):
+        ok, _ = should_process(
+            scene(stash_ids=[{"endpoint": "x", "stash_id": "abc"}]),
+            settings(require_stash_id=True),
+        )
+        self.assertTrue(ok)
+
+    def test_no_stash_id_processed_by_default(self):
+        # #127: a null-StashID scene must NOT be silently skipped when the gate is off.
+        ok, _ = should_process(scene(stash_ids=[]), settings(require_stash_id=False))
+        self.assertTrue(ok)
+
+
+class TestRequiredTagsGate(unittest.TestCase):
+    def test_empty_is_noop(self):
+        ok, _ = should_process(scene(tags=[]), settings(required_tags=[]))
+        self.assertTrue(ok)
+
+    def test_passes_when_scene_has_a_required_tag(self):
+        ok, _ = should_process(
+            scene(tags=[{"name": "curated"}, {"name": "hd"}]),
+            settings(required_tags=["curated"]),
+        )
+        self.assertTrue(ok)
+
+    def test_any_match_passes_with_one_of_many(self):
+        ok, _ = should_process(
+            scene(tags=[{"name": "hd"}]),
+            settings(required_tags=["curated", "hd"]),
+        )
+        self.assertTrue(ok)
+
+    def test_blocks_when_no_required_tag_present(self):
+        ok, reason = should_process(
+            scene(tags=[{"name": "hd"}]),
+            settings(required_tags=["curated"]),
+        )
+        self.assertFalse(ok)
+        self.assertEqual(reason, "missing_required_tag")
+
+    def test_blocks_when_scene_has_no_tags(self):
+        ok, reason = should_process(scene(tags=[]), settings(required_tags=["curated"]))
+        self.assertFalse(ok)
+        self.assertEqual(reason, "missing_required_tag")
+
+
+class TestDirectoryGate(unittest.TestCase):
+    def test_include_match_passes(self):
+        ok, _ = should_process(
+            scene(files=[{"path": "/media/curated/a.mp4"}]),
+            settings(include_paths=["/media/curated/*"]),
+        )
+        self.assertTrue(ok)
+
+    def test_include_recurses_into_subdirs(self):
+        ok, _ = should_process(
+            scene(files=[{"path": "/media/curated/sub/a.mp4"}]),
+            settings(include_paths=["/media/curated/*"]),
+        )
+        self.assertTrue(ok)
+
+    def test_outside_include_blocks(self):
+        ok, reason = should_process(
+            scene(files=[{"path": "/media/other/a.mp4"}]),
+            settings(include_paths=["/media/curated/*"]),
+        )
+        self.assertFalse(ok)
+        self.assertEqual(reason, "outside_include_paths")
+
+    def test_exclude_blocks(self):
+        ok, reason = should_process(
+            scene(files=[{"path": "/media/trash/a.mp4"}]),
+            settings(exclude_paths=["/media/trash/*"]),
+        )
+        self.assertFalse(ok)
+        self.assertEqual(reason, "excluded_path")
+
+    def test_exclude_beats_include(self):
+        ok, reason = should_process(
+            scene(files=[{"path": "/media/curated/bad/a.mp4"}]),
+            settings(include_paths=["/media/curated/*"], exclude_paths=["*/bad/*"]),
+        )
+        self.assertFalse(ok)
+        self.assertEqual(reason, "excluded_path")
+
+    def test_case_insensitive(self):
+        ok, _ = should_process(
+            scene(files=[{"path": "/Media/Curated/A.MP4"}]),
+            settings(include_paths=["/media/curated/*"]),
+        )
+        self.assertTrue(ok)
+
+    def test_multifile_passes_if_any_file_included(self):
+        ok, _ = should_process(
+            scene(files=[{"path": "/media/other/a.mp4"}, {"path": "/media/curated/a.mp4"}]),
+            settings(include_paths=["/media/curated/*"]),
+        )
+        self.assertTrue(ok)
+
+    def test_multifile_blocked_if_any_file_excluded(self):
+        ok, reason = should_process(
+            scene(files=[{"path": "/media/curated/a.mp4"}, {"path": "/media/trash/b.mp4"}]),
+            settings(include_paths=["/media/curated/*"], exclude_paths=["/media/trash/*"]),
+        )
+        self.assertFalse(ok)
+        self.assertEqual(reason, "excluded_path")
+
+
+class TestAndCombination(unittest.TestCase):
+    def test_all_gates_must_pass(self):
+        ok, _ = should_process(
+            scene(
+                organized=True,
+                stash_ids=[{"stash_id": "abc"}],
+                tags=[{"name": "curated"}],
+                files=[{"path": "/media/curated/a.mp4"}],
+            ),
+            settings(
+                organized_condition="require",
+                require_stash_id=True,
+                required_tags=["curated"],
+                include_paths=["/media/curated/*"],
+            ),
+        )
+        self.assertTrue(ok)
+
+    def test_first_failing_gate_reports_organized_first(self):
+        # organized is evaluated before tags: an unorganized, untagged scene reports organized.
+        ok, reason = should_process(
+            scene(organized=False, tags=[]),
+            settings(organized_condition="require", required_tags=["curated"]),
+        )
+        self.assertFalse(ok)
+        self.assertEqual(reason, "not_organized")
+
+
+class TestDescribeActiveConditions(unittest.TestCase):
+    def test_all_defaults_reports_none(self):
+        desc = describe_active_conditions(settings())
+        self.assertIn("none", desc.lower())
+
+    def test_organized_require_reported(self):
+        self.assertIn("organized=require", describe_active_conditions(settings(organized_condition="require")))
+
+    def test_stash_id_reported(self):
+        self.assertIn("stashID", describe_active_conditions(settings(require_stash_id=True)))
+
+    def test_tags_reported(self):
+        desc = describe_active_conditions(settings(required_tags=["curated", "hd"]))
+        self.assertIn("curated", desc)
+        self.assertIn("hd", desc)
+
+    def test_paths_reported(self):
+        desc = describe_active_conditions(settings(include_paths=["/m/c/*"], exclude_paths=["/m/t/*"]))
+        self.assertIn("/m/c/*", desc)
+        self.assertIn("/m/t/*", desc)
+
+    def test_combination_joins_gates(self):
+        desc = describe_active_conditions(settings(organized_condition="skip", required_tags=["x"]))
+        self.assertIn("organized=skip", desc)
+        self.assertIn("x", desc)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/plugins/mcMetadata/tests/test_settings.py
+++ b/plugins/mcMetadata/tests/test_settings.py
@@ -1,0 +1,89 @@
+"""
+Unit tests for settings mapping + the hookTriggerMode -> organizedCondition migration.
+
+map_settings is pure: it maps Stash's camelCase plugin config to the internal
+snake_case settings dict (with list-parsing and back-compat) without any Stash call.
+
+Run with: python -m pytest tests/test_settings.py -v
+"""
+
+import os
+import sys
+import unittest
+from unittest.mock import MagicMock
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+sys.modules["stashapi"] = MagicMock()
+sys.modules["stashapi.log"] = MagicMock()
+
+from plugin_settings import map_settings
+
+
+class TestNewConditionSettings(unittest.TestCase):
+    def test_defaults_are_noop_gates(self):
+        s = map_settings({})
+        self.assertEqual(s["organized_condition"], "ignore")
+        self.assertEqual(s["required_tags"], [])
+        self.assertEqual(s["include_paths"], [])
+        self.assertEqual(s["exclude_paths"], [])
+
+    def test_required_tags_parsed_and_trimmed(self):
+        s = map_settings({"requiredTags": " curated , hd ,, four-k "})
+        self.assertEqual(s["required_tags"], ["curated", "hd", "four-k"])
+
+    def test_include_and_exclude_paths_parsed(self):
+        s = map_settings({
+            "includePaths": "/media/curated/*, /media/keep/*",
+            "excludePaths": "*/trash/*",
+        })
+        self.assertEqual(s["include_paths"], ["/media/curated/*", "/media/keep/*"])
+        self.assertEqual(s["exclude_paths"], ["*/trash/*"])
+
+    def test_organized_condition_passthrough(self):
+        self.assertEqual(map_settings({"organizedCondition": "require"})["organized_condition"], "require")
+        self.assertEqual(map_settings({"organizedCondition": "skip"})["organized_condition"], "skip")
+
+    def test_unknown_organized_condition_falls_back_to_ignore(self):
+        self.assertEqual(map_settings({"organizedCondition": "bogus"})["organized_condition"], "ignore")
+
+
+class TestHookTriggerModeMigration(unittest.TestCase):
+    def test_legacy_on_organized_maps_to_require(self):
+        s = map_settings({"hookTriggerMode": "on_organized"})
+        self.assertEqual(s["organized_condition"], "require")
+
+    def test_legacy_always_maps_to_ignore(self):
+        s = map_settings({"hookTriggerMode": "always"})
+        self.assertEqual(s["organized_condition"], "ignore")
+
+    def test_new_key_overrides_legacy(self):
+        s = map_settings({"organizedCondition": "skip", "hookTriggerMode": "on_organized"})
+        self.assertEqual(s["organized_condition"], "skip")
+
+    def test_no_legacy_key_defaults_ignore(self):
+        self.assertEqual(map_settings({})["organized_condition"], "ignore")
+
+
+class TestExistingSettingsPreserved(unittest.TestCase):
+    def test_safe_defaults_retained(self):
+        s = map_settings({})
+        self.assertTrue(s["dry_run"])           # default-on safety
+        self.assertFalse(s["enable_hook"])       # default-off safety
+        self.assertFalse(s["require_stash_id"])  # #127: process all by default
+        self.assertEqual(s["renamer_multi_file_mode"], "all")
+        self.assertEqual(s["media_server"], "jellyfin")
+
+    def test_nfo_exclude_fields_still_parsed(self):
+        s = map_settings({"nfoExcludeFields": "Genre, Rating"})
+        self.assertEqual(s["nfo_exclude_fields"], ["genre", "rating"])
+
+    def test_values_passed_through(self):
+        s = map_settings({"enableHook": True, "requireStashId": True, "renamerPath": "/x"})
+        self.assertTrue(s["enable_hook"])
+        self.assertTrue(s["require_stash_id"])
+        self.assertEqual(s["renamer_path"], "/x")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

mcMetadata can now control **which scenes it processes**, with the same conditions applied to both the scene-update hook and the **Bulk Update Scenes** task:

- **Organized Condition** — `require` / `skip` / `ignore`
- **Required Tags** — process only scenes that have at least one
- **Include / Exclude Paths** — path globs (exclude wins)
- **Require StashDB Link** — now applies to the bulk task too

Each condition is optional and they combine with AND. The bulk **Dry Run** now ends with a skip-reason histogram + a sample, so you can preview what would be processed before a live run:

```
[DRY RUN] Bulk scan complete: 1240 scanned
  -> processed: 312
  -> skipped: 928
      not_organized........... 700
      missing_required_tag.... 180
      outside_include_paths... 48
  sample skipped: [41] not_organized | [88] missing_required_tag
```

## Fixes #127

The **Bulk Update Scenes** task no longer silently skips scenes without a StashID — it now processes all scenes (subject to your conditions). On the test library (16 scenes, 10 without a StashID), the bulk task now processes all 16; previously it processed only the 6 StashDB-linked ones.

## Migrating from Hook Trigger Mode

`Hook Trigger Mode` is superseded by `Organized Condition` and auto-migrates when Organized Condition is unset: `on_organized` → `require`, `always` → `ignore`. Existing setups keep working with no changes.

## Notes for reviewers

- A single `should_process(scene, settings)` gate is the source of truth, shared by the hook and bulk paths. The bulk task pushes `organized` / StashID into the server-side `findScenes` filter as a **superset** optimization; directory globs and tags are evaluated client-side, and `should_process` remains authoritative.
- 121 unit tests (gate, settings + migration, bulk/#127, histogram, startup log). Verified live on the stash-test instance: #127, organized server-prefilter, required-tag histogram.

Closes #127