### PR TITLE
Tag Manager: state & persistence overhaul (v0.5.0)

### DIFF
--- a/docs/plans/2026-06-19-tagmanager-state-overhaul-design.md
+++ b/docs/plans/2026-06-19-tagmanager-state-overhaul-design.md
@@ -1,0 +1,125 @@
+# Tag Manager — State & Persistence Overhaul (design)
+
+> **Status:** 🟢 ready (scoped, design validated 2026-06-19)
+> **Repo:** stash-plugins · **Plugin:** tagManager (v0.4.1)
+> **Theme:** ROADMAP P1 "Tag Manager state/persistence overhaul" (Theme D in `docs/CATCHUP-2026-06.md`)
+> **This pass (v0.5.0):** #122, #124, #126 + 3 folded hardening follow-ups
+> **Fast-follow (v0.5.x):** #125 (in-UI alias-conflict resolution) — deliberately out of scope here
+
+## Problem
+
+The Tag Manager's open issues share one spine: **the frontend trusts its in-memory
+state instead of the server**, in two places.
+
+- **Persistence (#122)** — category→parent mappings revert to "create new." `resolveCategoryParents`
+  (`tag-manager.js:915-963`) correctly keys on `categoryMappings[catName]`, so the lookup is fine;
+  the write path is not. Saves go through `savePluginConfigPatch` (`tag-manager.js:120-138`), a
+  **non-atomic read-whole-config-then-overwrite**, and `initializeDefaultSettings()`
+  (`tag-manager.js:147-176`) runs **fire-and-forget** at startup doing its own backfill patch — so
+  one save clobbers another, and a failed write reverts silently.
+- **Reactivity (#124)** — after a merge/conflict-fix the UI re-renders from a stale in-memory
+  `localTags` array and never re-fetches (`performTagMerge` re-renders at `tag-manager.js:812` without
+  a refetch). Fixing a conflicting tag in another Stash tab and returning shows nothing until a full
+  page reload.
+- **Leave parents alone (#126)** — import always creates/assigns category parents (unless the user
+  clicks a per-import "Import without Parents" button); there's no persistent setting for users who
+  maintain their own nested hierarchy.
+
+Plus three hardening follow-ups carried from the #128 review (do not drop).
+
+## Goals (this pass → v0.5.0)
+
+1. **#122** — category→parent mappings persist reliably and survive sessions.
+2. **#124** — tag data reflects server changes (ours + made elsewhere) without a full reload.
+3. **#126** — a persistent "leave parent tags alone" setting (full bypass of category parents).
+4. Harden: await/`.catch` `initializeDefaultSettings()`; restore `syncDryRun` try/except;
+   `safe_int` for `fuzzyThreshold`.
+
+## Non-goals (YAGNI)
+
+- **#125** in-UI alias-conflict resolution — separate fast-follow (the meatiest UI work).
+- No incremental/delta tag fetching — debounced full `findTags` refetch is enough for now.
+- No change to scene sync's parent behavior (it already never creates/modifies parents).
+- "Leave parents alone" does **not** remove existing parent relationships — it only stops the
+  plugin creating/assigning new ones.
+
+## Design
+
+### 1. Persistence reliability (#122)
+
+1. **Await the bootstrap.** Make `initializeDefaultSettings()` awaited and `.catch`-guarded before
+   any save-triggering UI is wired up. Closes the backfill-vs-user-save race and the brief window
+   where `DEFAULTS` is `{}`. *(= folded hardening follow-up; it is part of #122's root cause.)*
+2. **Write-through-and-verify.** `saveCategoryMappings()` is `await`ed at both call sites (import
+   flow `tag-manager.js:1378-1386`; merge dialog `~2753`). After writing, read the config back and
+   confirm `categoryMappings` round-tripped; on mismatch/failure show a toast instead of failing
+   silently.
+3. **Serialize config writes.** `savePluginConfigPatch` keeps its read-merge-write shape (Stash's
+   `configurePlugin` overwrites the whole map) but funnels all writes through a single in-flight
+   promise chain, so concurrent savers (mappings, blacklist, settings, backfill) merge onto the
+   latest persisted config rather than a stale snapshot.
+
+Net: the selected parent persists; next session `resolveCategoryParents` resolves `'saved'`, not `'create'`.
+
+### 2. Reactivity / refresh (#124)
+
+- **`refreshLocalTags()`** — re-runs `fetchLocalTags()` (`findTags(per_page:-1)`, `tag-manager.js:286-301`)
+  and re-renders. Replace the by-hand `localTags` edits after **merge / import / link / alias-fix /
+  parent change** with a call to it (single source of truth: re-fetch, don't hand-patch).
+- **On regaining focus** — `visibilitychange`/`focus` listeners call `refreshLocalTags()` (the literal
+  #124 case: fix a conflict in another tab, come back).
+- **Guarded** — a `busy` flag skips/defers refresh while a modal/import is mid-flight, running the
+  queued refresh when it clears; reconcile selections by tag id (drop ids that vanished, e.g. merged
+  away; keep the rest); debounce focus events.
+- **Listener lifecycle** — register on page mount, remove on unmount (also subsumes a known
+  event-listener-cleanup concern).
+
+### 3. "Leave parent tags alone" setting (#126)
+
+New BOOLEAN `leaveParentTagsAlone` (default **OFF**) in `tagManager.yml` + `default_settings.json`,
+read in `loadSettings`. When **ON**: import skips the category-preview modal and imports tags flat —
+no parent creation, no category-derived `parent_ids`, no parent-description backfill. Existing parent
+relationships are never removed. Scene sync unchanged.
+
+### 4. Python hardening
+
+- `handle_sync_scene_tags`: restore `try/except` around reading `syncDryRun`, defaulting to
+  **dry-run = true** on missing/malformed config.
+- Replace `int(config.get("fuzzyThreshold", default))` with `safe_int(value, default)` tolerating
+  `""`/`None`/non-numeric.
+
+## Testing strategy
+
+Extract new logic into pure, testable units (the frontend is one large IIFE; DOM wiring stays manual).
+
+- **Python (pytest)** — `safe_int` table (`""`, `None`, `"abc"`, `"75"` → 75/default);
+  `syncDryRun` resolution defaults to true on malformed config. Follow existing `tagManager/tests`
+  + mcMetadata patterns.
+- **JS (node `test_*.js`, the repo's existing harness)** for extracted pure helpers:
+  - config-write **serialization queue** — concurrent patches merge with no lost keys;
+  - **save-verify** — `verifyPersisted(written, readback)` flags mismatch;
+  - refresh **selection reconciliation** — drop vanished ids, keep the rest;
+  - `leaveParentTagsAlone` import-decision gating.
+- **Manual matrix on stash-test** — #122 (set mapping → reload → persists as `'saved'`); #124 (fix a
+  conflict in another tab → return refreshes; merge reflects without reload); #126 (setting on →
+  import skips modal, no parents created).
+
+## Rollout
+
+1. Branch/worktree under `.worktrees/`; TDD per the test plan.
+2. Version bump **0.4.1 → 0.5.0**; README (new setting + persistence/refresh notes) + changelog.
+3. Deploy to **stash-test** (`10.0.0.4:6971`) via rsync, reload, run the manual matrix.
+4. Merge to `main` → Pages Action republishes the index.
+
+## Fast-follow — #125 (separate effort)
+
+In-UI alias-conflict resolution for bulk import: surface per-tag conflicts (currently caught and only
+`console.error`'d + counted, `tag-manager.js:1371-1374`) with actions — merge into / merge here /
+navigate to tag / keep separate. Scoped after v0.5.0 ships.
+
+## Open questions / future work
+
+- If `leaveParentTagsAlone` proves too blunt, consider the softer "link to existing parents but
+  create none" variant (rejected here for simplicity).
+- Focus-refetch on very large tag libraries — revisit delta fetching only if `findTags(per_page:-1)`
+  becomes a felt cost.

--- a/plugins/tagManager/README.md
+++ b/plugins/tagManager/README.md
@@ -86,6 +86,7 @@ Go to **Settings → Plugins → Tag Manager**:
 | Fuzzy Match Threshold | Minimum score (0-100) for fuzzy matches | 80 |
 | Tags Per Page | Number of tags shown per page | 25 |
 | Scene Tag Sync - Dry Run | Preview sync without making changes | Enabled |
+| Leave Parent Tags Alone | Import/match tags flat — don't create or assign category parent tags, keeping your own hierarchy untouched | Off |
 | Tag Blacklist | Patterns to exclude from matching | Empty |
 
 ## Troubleshooting
@@ -172,6 +173,15 @@ tagManager/
 ├── cache/                 # Tag cache files (auto-created)
 └── tests/                 # Test suite
 ```
+
+## Changelog
+
+### v0.5.0
+
+- **Category mappings now persist reliably** (#122): config writes are serialized and verified after saving, so a selected parent tag no longer reverts to "create new." A failed save now surfaces a toast instead of silently dropping.
+- **Tag list refreshes without a full page reload** (#124): returning to the tab (e.g. after fixing a conflicting tag elsewhere) and finishing a merge/import now re-fetch from Stash automatically.
+- **New "Leave Parent Tags Alone" setting** (#126): import/match tags flat without creating or assigning category parent tags, for users who maintain their own nested hierarchy.
+- Hardened plugin config reads (empty/cleared numeric settings and malformed config no longer error).
 
 ## License
 

--- a/plugins/tagManager/default_settings.json
+++ b/plugins/tagManager/default_settings.json
@@ -5,6 +5,7 @@
   "pageSize": 25,
   "preferStashBoxName": false,
   "preferStashBoxDescription": false,
+  "leaveParentTagsAlone": false,
   "syncDryRun": true,
   "categoryMappings": "{}",
   "tagBlacklist": ""

--- a/plugins/tagManager/tag-manager.js
+++ b/plugins/tagManager/tag-manager.js
@@ -109,32 +109,55 @@
   }
 
   /**
+   * Serialize async config writes so concurrent read-merge-write patches can't
+   * clobber each other. Each enqueued task runs after the prior one settles and
+   * resolves to its own result; a failure never poisons the chain.
+   */
+  function createConfigWriteQueue() {
+    let chain = Promise.resolve();
+    return function enqueue(task) {
+      const result = chain.then(task, task);
+      chain = result.then(() => {}, () => {});
+      return result;
+    };
+  }
+  const _enqueueConfigWrite = createConfigWriteQueue();
+
+  /**
+   * Verify that every key in `written` round-tripped into the persisted `readback`.
+   */
+  function valuesPersisted(written, readback) {
+    return Object.keys(written).every(
+      (k) => JSON.stringify(readback?.[k]) === JSON.stringify(written[k])
+    );
+  }
+
+  /**
    * Merge `partialInput` into the current plugin settings and persist.
    *
    * Stash overwrites `plugins.settings.<pluginId>` on each `configurePlugin` call,
-   * so we load the existing map, shallow-merge, then send the full object.
+   * so we load the existing map, shallow-merge, then send the full object. Writes
+   * are serialized through a single queue: each patch merges onto the latest
+   * persisted config (not a stale snapshot), so concurrent savers don't clobber.
    *
    * @param {Record<string, unknown>} partialInput
    * @returns {Promise<Record<string, unknown>>} The saved settings map
    */
-  async function savePluginConfigPatch(partialInput) {
-    const current = await getPluginConfig();
-
-    // Merge new settings with existing settings
-    const next = { ...current, ...partialInput };
-
-    // Send the full object to the backend
+  async function _writeFullConfig(next) {
     const mutation = `
       mutation ConfigurePlugin($plugin_id: ID!, $input: Map!) {
         configurePlugin(plugin_id: $plugin_id, input: $input)
       }
     `;
-    await graphqlRequest(mutation, {
-      plugin_id: PLUGIN_ID,
-      input: next,
-    });
-
+    await graphqlRequest(mutation, { plugin_id: PLUGIN_ID, input: next });
     return next;
+  }
+
+  function savePluginConfigPatch(partialInput) {
+    return _enqueueConfigWrite(async () => {
+      const current = await getPluginConfig();
+      return _writeFullConfig({ ...current, ...partialInput });
+    });
   }
 
   /**
@@ -159,20 +182,36 @@
       settings = { ...DEFAULTS };
     }
 
-    // Compute keys that are missing in stash settings
-    const pluginConfig = await getPluginConfig();
-    const missingDefaults = {};
-    for (const [key, value] of Object.entries(DEFAULTS)) {
-      if (pluginConfig[key] === undefined || pluginConfig[key] === null) {
-        missingDefaults[key] = value;
+    // Backfill missing defaults atomically inside the config-write queue: read the
+    // LATEST persisted config and write in one critical section, so this can never
+    // clobber a concurrent user save (e.g. category mappings) with a stale default.
+    await _enqueueConfigWrite(async () => {
+      const pluginConfig = await getPluginConfig();
+      const missingDefaults = {};
+      for (const [key, value] of Object.entries(DEFAULTS)) {
+        if (pluginConfig[key] === undefined || pluginConfig[key] === null) {
+          missingDefaults[key] = value;
+        }
       }
-    }
+      if (Object.keys(missingDefaults).length > 0) {
+        await _writeFullConfig({ ...pluginConfig, ...missingDefaults });
+        console.info("[tagManager] Persisted missing defaults:", Object.keys(missingDefaults));
+      }
+    });
+  }
 
-    // Add missing defaults to stash settings without overwriting existing user values
-    if (Object.keys(missingDefaults).length > 0) {
-      await savePluginConfigPatch(missingDefaults);
-      console.info("[tagManager] Persisted missing defaults:", Object.keys(missingDefaults));
+  /**
+   * Idempotent gate so the backfill runs exactly once and callers can await it
+   * (ensures DEFAULTS is populated before settings are read). Never rejects.
+   */
+  let _initDefaultsPromise = null;
+  function ensureDefaultsInitialized() {
+    if (!_initDefaultsPromise) {
+      _initDefaultsPromise = initializeDefaultSettings().catch((e) => {
+        console.error("[tagManager] initializeDefaultSettings failed:", e);
+      });
     }
+    return _initDefaultsPromise;
   }
 
   /**
@@ -206,6 +245,7 @@
         pageSize: parseInt(pluginConfig.pageSize) || DEFAULTS.pageSize,
         preferStashBoxName: pluginConfig.preferStashBoxName ?? DEFAULTS.preferStashBoxName,
         preferStashBoxDescription: pluginConfig.preferStashBoxDescription ?? DEFAULTS.preferStashBoxDescription,
+        leaveParentTagsAlone: pluginConfig.leaveParentTagsAlone ?? DEFAULTS.leaveParentTagsAlone,
       };
 
       // Load configured stash-boxes
@@ -270,13 +310,22 @@
    * Save category mappings to plugin settings
    */
   async function saveCategoryMappings() {
+    const written = { categoryMappings: JSON.stringify(categoryMappings) };
     try {
-      await savePluginConfigPatch({
-        categoryMappings: JSON.stringify(categoryMappings)
-      });
+      await savePluginConfigPatch(written);
+      // Verify it actually round-tripped — a silent drop was the root of #122.
+      const readback = await getPluginConfig();
+      if (!valuesPersisted(written, readback)) {
+        throw new Error("category mappings did not round-trip");
+      }
       console.debug("[tagManager] Saved category mappings");
+      return true;
     } catch (e) {
       console.error("[tagManager] Failed to save category mappings:", e);
+      if (typeof showToast === "function") {
+        showToast("Failed to save category mappings — they may not persist.", "error");
+      }
+      return false;
     }
   }
 
@@ -308,6 +357,48 @@
 
     const data = await graphqlRequest(query);
     return data?.findTags?.tags || [];
+  }
+
+  // --- #124 reactivity: keep localTags in sync with the server ----------------
+  let _activeContainer = null;   // set while the Tag Manager page is mounted
+  let _refreshTimer = null;
+
+  /**
+   * Drop selections for tags that no longer exist (e.g. merged away). Pure.
+   */
+  function reconcileSelections(prevSelectedIds, freshTags) {
+    const ids = new Set(freshTags.map((t) => t.id));
+    const next = new Set();
+    for (const id of prevSelectedIds) {
+      if (ids.has(id)) next.add(id);
+    }
+    return next;
+  }
+
+  /**
+   * Re-fetch local tags and re-render so the UI reflects changes made here or in
+   * another tab (#124). Modals live on document.body, so re-rendering the page
+   * container is safe under an open modal; only an active import loop defers it
+   * (the import does its own render, then calls this for server-truth reconcile).
+   */
+  async function refreshLocalTags() {
+    if (!_activeContainer || isImporting) return;
+    try {
+      localTags = await fetchLocalTags();
+      selectedForImport = reconcileSelections(selectedForImport, localTags);
+      if (_activeContainer) renderPage(_activeContainer);
+    } catch (e) {
+      console.error("[tagManager] Failed to refresh local tags:", e);
+    }
+  }
+
+  /** Debounced refresh for focus/visibility events. */
+  function scheduleRefresh() {
+    if (_refreshTimer) clearTimeout(_refreshTimer);
+    _refreshTimer = setTimeout(() => {
+      _refreshTimer = null;
+      refreshLocalTags();
+    }, 300);
   }
 
   /**
@@ -810,6 +901,7 @@
 
       showStatus(`Merged "${sourceTag.name}" into "${destinationTag.name}" and linked to StashDB`, 'success');
       renderPage(container);
+      await refreshLocalTags(); // #124: pull server truth after the merge
 
       return { success: true };
     } catch (e) {
@@ -905,6 +997,14 @@
 
     // Limit to top 5
     return matches.slice(0, 5);
+  }
+
+  /**
+   * #126: whether to create/assign category parent tags during sync/import.
+   * False when the user has opted to leave their own tag hierarchy untouched.
+   */
+  function shouldResolveParents(settings) {
+    return !settings.leaveParentTagsAlone;
   }
 
   /**
@@ -1212,21 +1312,24 @@
     if (selectedForImport.size === 0) return;
     if (isImporting) return;
 
-    // Resolve categories among selected tags
-    const categoryResolutions = resolveCategoryParents(selectedForImport);
-    const hasCategories = Object.keys(categoryResolutions).length > 0;
-
     let parentMap = null;
     let remember = false;
     let resolutions = null;
 
-    if (hasCategories) {
-      const result = await showCategoryPreviewModal(categoryResolutions);
-      if (result === 'cancel') return;
-      if (result !== null) {
-        parentMap = result.parentMap;
-        remember = result.remember;
-        resolutions = result.resolutions;
+    // #126: when "leave parent tags alone" is on, import flat — skip the category
+    // preview modal and all parent creation/assignment (parentMap stays null).
+    if (shouldResolveParents(settings)) {
+      const categoryResolutions = resolveCategoryParents(selectedForImport);
+      const hasCategories = Object.keys(categoryResolutions).length > 0;
+
+      if (hasCategories) {
+        const result = await showCategoryPreviewModal(categoryResolutions);
+        if (result === 'cancel') return;
+        if (result !== null) {
+          parentMap = result.parentMap;
+          remember = result.remember;
+          resolutions = result.resolutions;
+        }
       }
     }
 
@@ -1382,7 +1485,7 @@
           categoryMappings[catName] = finalId;
         }
       }
-      saveCategoryMappings();
+      await saveCategoryMappings();
     }
 
     selectedForImport.clear();
@@ -1402,6 +1505,7 @@
     setTimeout(() => {
       isImporting = false;
       renderPage(container);
+      refreshLocalTags(); // #124: reconcile with server truth after import
     }, 1500);
   }
 
@@ -1485,6 +1589,7 @@
     setTimeout(() => {
       isImporting = false;
       renderPage(container);
+      refreshLocalTags(); // #124: reconcile with server truth after import
     }, 1500);
   }
 
@@ -2716,9 +2821,9 @@
       // Use sanitized aliases
       updateInput.aliases = sanitizedAliases;
 
-      // Handle parent tag from category
+      // Handle parent tag from category (#126: skipped when leaving parents alone)
       let parentTagId = null;
-      if (hasCategory && selectedParentId) {
+      if (shouldResolveParents(settings) && hasCategory && selectedParentId) {
         if (selectedParentId === '__create__') {
           // Create the parent tag
           try {
@@ -2751,7 +2856,7 @@
         const rememberCheckbox = modal.querySelector('#tm-remember-mapping');
         if (rememberCheckbox?.checked && parentTagId) {
           categoryMappings[stashdbTag.category.name] = parentTagId;
-          saveCategoryMappings(); // Fire and forget
+          await saveCategoryMappings();
         }
       }
 
@@ -3191,6 +3296,9 @@
         setPageTitle("Tag Matcher | Stash");
         containerRef.current.innerHTML = '<div class="tag-manager"><div class="tm-loading">Loading configuration...</div></div>';
 
+        // Ensure defaults are loaded/backfilled before reading settings, so
+        // loadSettings sees a populated DEFAULTS and the backfill can't race.
+        await ensureDefaultsInitialized();
         await loadSettings();
         await loadCategoryMappings();
         await loadBlacklist();
@@ -3232,10 +3340,30 @@
 
         setInitialized(true);
         console.debug("[tagManager] Initialization complete");
+        _activeContainer = containerRef.current;
         renderPage(containerRef.current);
       }
 
       init();
+
+      // #124: refresh tag data when returning to the tab (e.g. after fixing a
+      // conflicting tag elsewhere). Listeners are cleaned up on unmount.
+      const onFocus = () => scheduleRefresh();
+      const onVisibility = () => {
+        if (document.visibilityState === "visible") scheduleRefresh();
+      };
+      window.addEventListener("focus", onFocus);
+      document.addEventListener("visibilitychange", onVisibility);
+
+      return () => {
+        window.removeEventListener("focus", onFocus);
+        document.removeEventListener("visibilitychange", onVisibility);
+        if (_refreshTimer) {
+          clearTimeout(_refreshTimer);
+          _refreshTimer = null;
+        }
+        _activeContainer = null;
+      };
     }, []);
 
     return React.createElement('div', {
@@ -4594,7 +4722,7 @@
   }
 
   // Initialize
-  initializeDefaultSettings();
+  ensureDefaultsInitialized();
   registerRoute();
   setupNavButtonInjection();
   console.log('[tagManager] Plugin loaded');

--- a/plugins/tagManager/tagManager.yml
+++ b/plugins/tagManager/tagManager.yml
@@ -1,6 +1,6 @@
 name: Tag Manager
 description: Match and sync local tags with stash-box endpoints. Features multi-endpoint support, tag caching, layered search (exact, fuzzy, synonym), and field-by-field merge dialog.
-version: 0.4.1
+version: 0.5.0
 url: https://github.com/carrotwaxr/stash-plugins
 
 ui:
@@ -39,6 +39,10 @@ settings:
   preferStashBoxDescription:
     displayName: Default to Stash-Box Description
     description: In the merge dialog, default the Description selection to the stash-box value instead of keeping the local description.
+    type: BOOLEAN
+  leaveParentTagsAlone:
+    displayName: Leave Parent Tags Alone
+    description: Don't create or assign category parent tags when importing/matching. Keeps your own tag hierarchy untouched (imports tags flat). Default is off.
     type: BOOLEAN
   categoryMappings:
     displayName: Category Mappings (Internal)

--- a/plugins/tagManager/tag_manager.py
+++ b/plugins/tagManager/tag_manager.py
@@ -218,6 +218,31 @@ def clear_cache(endpoint_url):
     return True  # Already cleared
 
 
+def safe_int(value, default):
+    """Coerce a stored config value to int, falling back to default.
+
+    Stash stores an empty string for a cleared numeric field, and backfill only
+    fills *missing* keys (not ""), so a bare int() can throw on real config.
+    """
+    try:
+        return int(str(value).strip())
+    except (TypeError, ValueError, AttributeError):
+        return default
+
+
+def resolve_sync_dry_run(stash_config):
+    """Read syncDryRun from a (possibly malformed) Stash config, safe-defaulting.
+
+    Never raise: a missing/None config or plugin entry falls back to the safe
+    dry-run default so a bad config can't trigger unintended writes.
+    """
+    try:
+        plugin_config = (stash_config.get("plugins") or {}).get(PLUGIN_ID) or {}
+        return plugin_config.get("syncDryRun", DEFAULT_PLUGIN_SETTINGS["syncDryRun"])
+    except (AttributeError, TypeError):
+        return DEFAULT_PLUGIN_SETTINGS["syncDryRun"]
+
+
 def get_settings_from_config(stash_config):
     """
     Extract plugin settings from Stash configuration.
@@ -237,8 +262,8 @@ def get_settings_from_config(stash_config):
         "stashdb_api_key": config.get("stashdbApiKey", ""),
         "enable_fuzzy": config.get("enableFuzzySearch", DEFAULT_PLUGIN_SETTINGS["enableFuzzySearch"]),
         "enable_synonyms": config.get("enableSynonymSearch", DEFAULT_PLUGIN_SETTINGS["enableSynonymSearch"]),
-        "fuzzy_threshold": int(config.get("fuzzyThreshold", DEFAULT_PLUGIN_SETTINGS["fuzzyThreshold"])),
-        "page_size": int(config.get("pageSize", DEFAULT_PLUGIN_SETTINGS["pageSize"])),
+        "fuzzy_threshold": safe_int(config.get("fuzzyThreshold", DEFAULT_PLUGIN_SETTINGS["fuzzyThreshold"]), DEFAULT_PLUGIN_SETTINGS["fuzzyThreshold"]),
+        "page_size": safe_int(config.get("pageSize", DEFAULT_PLUGIN_SETTINGS["pageSize"]), DEFAULT_PLUGIN_SETTINGS["pageSize"]),
         "tag_blacklist": config.get("tagBlacklist", DEFAULT_PLUGIN_SETTINGS["tagBlacklist"]),
     }
 
@@ -259,27 +284,33 @@ def handle_search(tag_name, stashdb_url, stashdb_api_key, settings, stashdb_tags
     """
     log.LogDebug(f"Searching for tag: {tag_name}")
 
+    # Read settings defensively — callers may pass a partial dict (defaults apply).
+    tag_blacklist = settings.get("tag_blacklist", DEFAULT_PLUGIN_SETTINGS["tagBlacklist"])
+    enable_fuzzy = settings.get("enable_fuzzy", DEFAULT_PLUGIN_SETTINGS["enableFuzzySearch"])
+    enable_synonyms = settings.get("enable_synonyms", DEFAULT_PLUGIN_SETTINGS["enableSynonymSearch"])
+    fuzzy_threshold = safe_int(settings.get("fuzzy_threshold", DEFAULT_PLUGIN_SETTINGS["fuzzyThreshold"]), DEFAULT_PLUGIN_SETTINGS["fuzzyThreshold"])
+
     # Load blacklist from settings
-    blacklist = Blacklist(settings["tag_blacklist"])
+    blacklist = Blacklist(tag_blacklist)
 
     # First try StashDB's name search (searches name + aliases)
     api_matches = search_tags_by_name(stashdb_url, stashdb_api_key, tag_name, limit=20)
 
     # If we have cached tags, also do local fuzzy matching
     local_matches = []
-    if stashdb_tags and settings["enable_fuzzy"]:
+    if stashdb_tags and enable_fuzzy:
         synonyms_path = os.path.join(get_plugin_dir(), "synonyms.json")
         synonyms = load_synonyms(synonyms_path)
 
         matcher = TagMatcher(
             stashdb_tags,
             synonyms=synonyms,
-            fuzzy_threshold=settings["fuzzy_threshold"]
+            fuzzy_threshold=fuzzy_threshold
         )
         local_matches = matcher.find_matches(
             tag_name,
-            enable_fuzzy=settings["enable_fuzzy"],
-            enable_synonyms=settings["enable_synonyms"],
+            enable_fuzzy=enable_fuzzy,
+            enable_synonyms=enable_synonyms,
             limit=20
         )
 
@@ -456,9 +487,8 @@ def handle_sync_scene_tags(server_connection, stash_config, api_key):
 
     log.LogInfo(f"Using stash-box endpoint: {stashdb_url}")
 
-    # Get dry_run setting from plugin config
-    plugin_config = stash_config.get("plugins", {}).get(PLUGIN_ID, {})
-    dry_run = plugin_config.get("syncDryRun", DEFAULT_PLUGIN_SETTINGS["syncDryRun"])
+    # Get dry_run setting from plugin config (safe-defaults on malformed config)
+    dry_run = resolve_sync_dry_run(stash_config)
 
     sync_settings = {
         "dry_run": dry_run

--- a/plugins/tagManager/tests/test_hardening.py
+++ b/plugins/tagManager/tests/test_hardening.py
@@ -1,0 +1,78 @@
+"""
+Tests for defensive config reads (folded #128-review hardening follow-ups).
+
+- safe_int tolerates empty/None/non-numeric stored values (Stash stores "" for a
+  cleared numeric field; backfill only fills *missing* keys, not "").
+- get_settings_from_config no longer crashes on an empty-string fuzzyThreshold/pageSize.
+- resolve_sync_dry_run falls back to the safe default on a missing/malformed config.
+
+Run with: python -m pytest tests/test_hardening.py -v
+"""
+
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from tag_manager import safe_int, get_settings_from_config, resolve_sync_dry_run
+from tag_manager import DEFAULT_PLUGIN_SETTINGS
+
+
+class TestSafeInt(unittest.TestCase):
+    def test_parses_numeric_string(self):
+        self.assertEqual(safe_int("75", 80), 75)
+
+    def test_passes_through_int(self):
+        self.assertEqual(safe_int(50, 80), 50)
+
+    def test_empty_string_falls_back(self):
+        self.assertEqual(safe_int("", 80), 80)
+
+    def test_none_falls_back(self):
+        self.assertEqual(safe_int(None, 80), 80)
+
+    def test_non_numeric_falls_back(self):
+        self.assertEqual(safe_int("abc", 80), 80)
+
+    def test_whitespace_tolerated(self):
+        self.assertEqual(safe_int("  90  ", 80), 90)
+
+
+class TestSettingsRobustToEmptyStrings(unittest.TestCase):
+    def test_empty_fuzzy_threshold_uses_default(self):
+        s = get_settings_from_config({"fuzzyThreshold": ""})
+        self.assertEqual(s["fuzzy_threshold"], DEFAULT_PLUGIN_SETTINGS["fuzzyThreshold"])
+
+    def test_empty_page_size_uses_default(self):
+        s = get_settings_from_config({"pageSize": ""})
+        self.assertEqual(s["page_size"], DEFAULT_PLUGIN_SETTINGS["pageSize"])
+
+    def test_valid_value_still_parsed(self):
+        s = get_settings_from_config({"fuzzyThreshold": "65"})
+        self.assertEqual(s["fuzzy_threshold"], 65)
+
+
+class TestResolveSyncDryRun(unittest.TestCase):
+    def test_reads_explicit_value(self):
+        cfg = {"plugins": {"tagManager": {"syncDryRun": False}}}
+        self.assertFalse(resolve_sync_dry_run(cfg))
+
+    def test_missing_defaults_to_safe(self):
+        self.assertEqual(resolve_sync_dry_run({}), DEFAULT_PLUGIN_SETTINGS["syncDryRun"])
+
+    def test_malformed_plugins_none_falls_back(self):
+        self.assertEqual(resolve_sync_dry_run({"plugins": None}), DEFAULT_PLUGIN_SETTINGS["syncDryRun"])
+
+    def test_malformed_plugin_entry_none_falls_back(self):
+        self.assertEqual(
+            resolve_sync_dry_run({"plugins": {"tagManager": None}}),
+            DEFAULT_PLUGIN_SETTINGS["syncDryRun"],
+        )
+
+    def test_none_config_falls_back(self):
+        self.assertEqual(resolve_sync_dry_run(None), DEFAULT_PLUGIN_SETTINGS["syncDryRun"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/plugins/tagManager/tests/test_leave_parents.js
+++ b/plugins/tagManager/tests/test_leave_parents.js
@@ -1,0 +1,38 @@
+/**
+ * Unit tests for the #126 leaveParentTagsAlone gate.
+ * MIRROR of shouldResolveParents from tag-manager.js.
+ *
+ * Run with: node plugins/tagManager/tests/test_leave_parents.js
+ */
+
+let passed = 0;
+let failed = 0;
+function test(name, fn) {
+  try { fn(); console.log(`✓ ${name}`); passed++; }
+  catch (e) { console.log(`✗ ${name}\n  Error: ${e.message}`); failed++; }
+}
+function assert(cond, msg) { if (!cond) throw new Error(msg || 'assertion failed'); }
+
+// ---- MIRROR of tag-manager.js: shouldResolveParents ----
+function shouldResolveParents(settings) {
+  return !settings.leaveParentTagsAlone;
+}
+
+console.log('\n=== shouldResolveParents tests ===\n');
+
+test('resolves parents when setting is off', () => {
+  assert(shouldResolveParents({ leaveParentTagsAlone: false }) === true);
+});
+
+test('resolves parents when setting is undefined (default)', () => {
+  assert(shouldResolveParents({}) === true);
+});
+
+test('skips parents when setting is on', () => {
+  assert(shouldResolveParents({ leaveParentTagsAlone: true }) === false);
+});
+
+console.log('\n=== Summary ===\n');
+console.log(`Passed: ${passed}`);
+console.log(`Failed: ${failed}`);
+if (failed > 0) process.exit(1);

--- a/plugins/tagManager/tests/test_persistence_overhaul.js
+++ b/plugins/tagManager/tests/test_persistence_overhaul.js
@@ -1,0 +1,110 @@
+/**
+ * Unit tests for the #122 persistence helpers.
+ *
+ * The frontend is a browser IIFE with no build step, so (per this repo's existing
+ * JS-test convention) these tests MIRROR the pure helpers from tag-manager.js and
+ * validate the algorithm. Keep them byte-identical to the source.
+ *
+ * Run with: node plugins/tagManager/tests/test_persistence_overhaul.js
+ */
+
+let passed = 0;
+let failed = 0;
+const tests = [];
+function test(name, fn) { tests.push([name, fn]); }
+function assert(cond, msg) { if (!cond) throw new Error(msg || 'assertion failed'); }
+function assertEqual(actual, expected, msg = '') {
+  if (JSON.stringify(actual) !== JSON.stringify(expected)) {
+    throw new Error(`${msg}\n  Expected: ${JSON.stringify(expected)}\n  Actual: ${JSON.stringify(actual)}`);
+  }
+}
+
+// ---- MIRROR of tag-manager.js: createConfigWriteQueue ----
+function createConfigWriteQueue() {
+  let chain = Promise.resolve();
+  return function enqueue(task) {
+    const result = chain.then(task, task); // run after prior settles (ok or error)
+    chain = result.then(() => {}, () => {}); // advance chain, never poisoned
+    return result;
+  };
+}
+
+// ---- MIRROR of tag-manager.js: valuesPersisted ----
+function valuesPersisted(written, readback) {
+  return Object.keys(written).every(
+    (k) => JSON.stringify(readback?.[k]) === JSON.stringify(written[k])
+  );
+}
+
+// ---- test helpers: a fake async config store with read/merge/write ----
+function makeStore(initial) {
+  let store = { ...initial };
+  return {
+    read: () => new Promise((res) => setTimeout(() => res({ ...store }), 5)),
+    write: (next) => new Promise((res) => setTimeout(() => { store = { ...next }; res(); }, 5)),
+    snapshot: () => ({ ...store }),
+  };
+}
+function readMergeWrite(store, partial) {
+  return async () => {
+    const current = await store.read();
+    const next = { ...current, ...partial };
+    await store.write(next);
+    return next;
+  };
+}
+
+console.log('\n=== createConfigWriteQueue tests ===\n');
+
+test('serialized read-merge-writes do not clobber each other', async () => {
+  const store = makeStore({});
+  const enqueue = createConfigWriteQueue();
+  await Promise.all([
+    enqueue(readMergeWrite(store, { a: 1 })),
+    enqueue(readMergeWrite(store, { b: 2 })),
+    enqueue(readMergeWrite(store, { c: 3 })),
+  ]);
+  assertEqual(store.snapshot(), { a: 1, b: 2, c: 3 }, 'all keys must survive');
+});
+
+test('each enqueued task resolves to its own result', async () => {
+  const enqueue = createConfigWriteQueue();
+  const [r1, r2] = await Promise.all([
+    enqueue(async () => 'first'),
+    enqueue(async () => 'second'),
+  ]);
+  assertEqual(r1, 'first');
+  assertEqual(r2, 'second');
+});
+
+test('a failing task does not break the chain', async () => {
+  const enqueue = createConfigWriteQueue();
+  let rejected = false;
+  await enqueue(async () => { throw new Error('boom'); }).catch(() => { rejected = true; });
+  const after = await enqueue(async () => 'ok');
+  assert(rejected, 'first task should reject');
+  assertEqual(after, 'ok', 'chain should keep running after a failure');
+});
+
+console.log('\n=== valuesPersisted tests ===\n');
+
+test('true when readback contains the written values', () => {
+  assert(valuesPersisted({ categoryMappings: '{"A":"1"}' }, { categoryMappings: '{"A":"1"}', other: 'x' }));
+});
+
+test('false when a written value is missing on readback', () => {
+  assert(!valuesPersisted({ categoryMappings: '{"A":"1"}' }, {}));
+});
+
+test('false when a written value differs on readback', () => {
+  assert(!valuesPersisted({ categoryMappings: '{"A":"1"}' }, { categoryMappings: '{"A":"2"}' }));
+});
+
+(async () => {
+  for (const [name, fn] of tests) {
+    try { await fn(); console.log(`✓ ${name}`); passed++; }
+    catch (e) { console.log(`✗ ${name}\n  Error: ${e.message}`); failed++; }
+  }
+  console.log(`\nPassed: ${passed}\nFailed: ${failed}`);
+  if (failed > 0) process.exit(1);
+})();

--- a/plugins/tagManager/tests/test_reactivity.js
+++ b/plugins/tagManager/tests/test_reactivity.js
@@ -1,0 +1,55 @@
+/**
+ * Unit tests for the #124 refresh reconciliation helper.
+ * MIRROR of reconcileSelections from tag-manager.js (browser IIFE, no build step).
+ *
+ * Run with: node plugins/tagManager/tests/test_reactivity.js
+ */
+
+let passed = 0;
+let failed = 0;
+function test(name, fn) {
+  try { fn(); console.log(`✓ ${name}`); passed++; }
+  catch (e) { console.log(`✗ ${name}\n  Error: ${e.message}`); failed++; }
+}
+function assertEqual(actual, expected, msg = '') {
+  if (JSON.stringify(actual) !== JSON.stringify(expected)) {
+    throw new Error(`${msg}\n  Expected: ${JSON.stringify(expected)}\n  Actual: ${JSON.stringify(actual)}`);
+  }
+}
+
+// ---- MIRROR of tag-manager.js: reconcileSelections ----
+function reconcileSelections(prevSelectedIds, freshTags) {
+  const ids = new Set(freshTags.map((t) => t.id));
+  const next = new Set();
+  for (const id of prevSelectedIds) {
+    if (ids.has(id)) next.add(id);
+  }
+  return next;
+}
+
+console.log('\n=== reconcileSelections tests ===\n');
+
+test('drops ids that no longer exist (merged away)', () => {
+  const result = reconcileSelections(new Set(['1', '2', '3']), [{ id: '1' }, { id: '3' }]);
+  assertEqual([...result].sort(), ['1', '3']);
+});
+
+test('keeps all when every selected tag still exists', () => {
+  const result = reconcileSelections(new Set(['1', '2']), [{ id: '1' }, { id: '2' }, { id: '9' }]);
+  assertEqual([...result].sort(), ['1', '2']);
+});
+
+test('empty selection stays empty', () => {
+  const result = reconcileSelections(new Set(), [{ id: '1' }]);
+  assertEqual([...result], []);
+});
+
+test('all dropped when none survive', () => {
+  const result = reconcileSelections(new Set(['7', '8']), [{ id: '1' }]);
+  assertEqual([...result], []);
+});
+
+console.log('\n=== Summary ===\n');
+console.log(`Passed: ${passed}`);
+console.log(`Failed: ${failed}`);
+if (failed > 0) process.exit(1);


### PR DESCRIPTION
## Summary

Fixes several Tag Manager issues that share one root cause — the UI trusting its in-memory state over the server:

- **Category mappings now persist (#122):** all plugin-config writes are serialized through one queue and the save is verified after writing, so a selected parent tag no longer reverts to "create new." A failed save now surfaces a toast instead of silently dropping.
- **Tag list refreshes without a full page reload (#124):** returning to the tab (e.g. after fixing a conflicting tag in another Stash tab) and finishing a merge/import now re-fetch from Stash automatically, reconciling your current selections.
- **New "Leave Parent Tags Alone" setting (#126):** import/match tags flat — don't create or assign category parent tags — for users who maintain their own nested hierarchy.

Also hardens plugin config reads (empty/cleared numeric settings and a malformed config no longer error), which fixes two pre-existing failing backend tests. Bumps to **v0.5.0**.

## Verification

- **Backend:** 87 pytest + 11 node test files green. Deployed to the test instance — loads clean at v0.5.0; `handle_search` runs with empty settings (the old crash path) and returns matches; the new setting round-trips; no tracebacks.
- ⚠️ **Frontend UI flows are not yet browser-verified.** The new logic is unit-tested at the helper level, but the persistence-across-reload, focus-refresh, and import-flat behaviors should get a manual pass in the Tag Manager UI before these issues are closed.

## Notes for reviewers

- A single config-write queue (`createConfigWriteQueue`) serializes every `configurePlugin` patch so concurrent savers (mappings, blacklist, settings, defaults backfill) can't clobber; `saveCategoryMappings` verifies the round-trip and the defaults backfill is atomic within the queue.
- `refreshLocalTags()` is the single refresh path (window focus / visibilitychange, debounced, + after merge/import); selections reconcile by tag id and an active import defers it.
- `leaveParentTagsAlone` gates both the import category-preview/parent-creation and the merge-dialog parent assignment.
- Frontend is a no-build-step browser IIFE, so JS unit tests mirror the pure helpers (per this repo's existing convention).

Addresses #122, #124, #126. (Recommend confirming the UI flows before closing the issues.)